### PR TITLE
Multi-athlete recording + tap-to-readiness UX

### DIFF
--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -6,12 +6,15 @@ import 'screens/dashboard_screen.dart';
 import 'screens/training_history_screen.dart';
 import 'screens/profile_screen.dart';
 import 'screens/settings_screen.dart';
+import 'screens/readiness_screen.dart';
 import 'screens/auth_gate.dart';
 import 'services/ble_service.dart';
 import 'services/database_service.dart';
 import 'services/settings_service.dart';
 import 'services/sync_service.dart';
 import 'services/auth_service.dart';
+import 'services/core_temp_service.dart';
+import 'services/hrv_service.dart';
 import 'supabase/supabase_client.dart';
 import 'services/app_initializer.dart';
 
@@ -84,21 +87,31 @@ class MyApp extends StatelessWidget {
       providers: [
         ChangeNotifierProvider(create: (_) => AuthService()),
         ChangeNotifierProvider(create: (_) => BLEService()),
+        ChangeNotifierProvider(create: (_) => CoreTempService()),
         ChangeNotifierProvider(create: (_) => DatabaseService.instance),
         ChangeNotifierProvider(create: (_) => SyncService()),
         ChangeNotifierProvider(create: (_) => SettingsService.instance),
+        ChangeNotifierProvider(create: (_) => HrvService.instance),
       ],
       child: MaterialApp(
         title: 'Linglong HR Monitor',
         theme: ThemeData(
-          primarySwatch: Colors.blue,
           useMaterial3: true,
-          brightness: Brightness.light,
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: const Color(0xFF0D2B5E), // navy
+            primary: const Color(0xFF0D2B5E),
+            secondary: const Color(0xFF00897B), // teal accent
+            brightness: Brightness.light,
+          ),
         ),
         darkTheme: ThemeData(
-          primarySwatch: Colors.blue,
           useMaterial3: true,
-          brightness: Brightness.dark,
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: const Color(0xFF0D2B5E),
+            primary: const Color(0xFF4A7FC1),   // lighter navy for dark bg
+            secondary: const Color(0xFF26A69A), // teal lighter for dark
+            brightness: Brightness.dark,
+          ),
         ),
         home: const AuthGate(child: _InitializerScreen()),
         routes: {
@@ -107,6 +120,7 @@ class MyApp extends StatelessWidget {
           '/history': (context) => const TrainingHistoryScreen(),
           '/profile': (context) => const ProfileScreen(),
           '/settings': (context) => const SettingsScreen(),
+          '/readiness': (context) => const ReadinessScreen(),
         },
       ),
     );

--- a/mobile_app/lib/screens/dashboard_screen.dart
+++ b/mobile_app/lib/screens/dashboard_screen.dart
@@ -13,6 +13,7 @@ import '../models/person.dart';
 import '../services/core_temp_service.dart';
 import '../services/hrv_service.dart';
 import 'team_readiness_screen.dart';
+import 'readiness_screen.dart';
 
 // Data point for heart rate with timestamp
 class HeartRateDataPoint {
@@ -33,7 +34,9 @@ class DashboardScreen extends StatefulWidget {
 }
 
 class _DashboardScreenState extends State<DashboardScreen> {
-  TrainingSession? _activeSession;
+  // Active sessions keyed by athleteId — one session per worn, paired sensor.
+  final Map<String, TrainingSession> _activeSessions = {};
+  bool _isRecording = false;
   Timer? _recordTimer;
   bool _isSyncing = false;
   bool _bleEnabled = true;
@@ -118,70 +121,118 @@ class _DashboardScreenState extends State<DashboardScreen> {
     debugPrint('=== _startRecording called ===');
     try {
       final dbService = Provider.of<DatabaseService>(context, listen: false);
-      debugPrint('DatabaseService obtained');
-
-      final session = await dbService.createSession(
-        title: 'Training Session ${DateTime.now().toString().substring(0, 16)}',
-        trainingType: 'general',
-      );
-      debugPrint('Session created: ${session.id}');
+      final bleService = Provider.of<BLEService>(context, listen: false);
 
       HrvService.instance.clearSessionData();
 
+      // Create one session per worn, paired device. Sensors that are paired
+      // but not producing HR (i.e. not currently worn) are skipped — they'll
+      // be picked up mid-session by the timer below if HR appears.
+      final timestamp = DateTime.now().toString().substring(0, 16);
+      int created = 0;
+      for (final device in bleService.connectedDevices) {
+        if (device.currentHeartRate == null) continue;
+        final athlete =
+            DatabaseService.instance.getAthleteForSensor(device.id);
+        if (athlete == null) continue;
+        if (_activeSessions.containsKey(athlete.id)) continue;
+
+        final session = await dbService.createSession(
+          title: 'Training Session $timestamp',
+          trainingType: 'general',
+          personId: athlete.id,
+        );
+        _activeSessions[athlete.id] = session;
+        created++;
+        debugPrint('Session ${session.id} created for ${athlete.name}');
+      }
+
+      if (created == 0) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text(
+                  'No worn paired sensors detected. Put on chest straps and try again.'),
+              backgroundColor: Colors.orange,
+              duration: Duration(seconds: 3),
+            ),
+          );
+        }
+        return;
+      }
+
       setState(() {
-        _activeSession = session;
+        _isRecording = true;
         _heartRateHistoryByDevice.clear();
       });
-      debugPrint('State updated, activeSession set');
 
-      // Record heart rate every second
-      _recordTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      // Record heart rate every second.
+      // Mid-session: if a paired sensor starts producing HR (athlete puts strap
+      // on late, or strap reconnects), spin up a session for that athlete.
+      _recordTimer = Timer.periodic(const Duration(seconds: 1), (timer) async {
         final bleService = Provider.of<BLEService>(context, listen: false);
 
-        // Record data for each connected device
-        for (var device in bleService.connectedDevices) {
-          if (device.currentHeartRate != null) {
-            final hrData = HeartRateData(
-              timestamp: DateTime.now(),
-              heartRate: device.currentHeartRate!,
-              deviceId: device.id,
-            );
+        for (final device in bleService.connectedDevices) {
+          if (device.currentHeartRate == null) continue;
 
-            _activeSession!.heartRateData.add(hrData);
+          final athlete =
+              DatabaseService.instance.getAthleteForSensor(device.id);
+          if (athlete == null) continue;
 
-            // Accumulate RR intervals for HRV analysis
-            if (device.rrIntervals != null && device.rrIntervals!.isNotEmpty) {
-              HrvService.instance.addRRIntervals(device.id, device.rrIntervals!);
+          // Lazily create a session for any newly-worn paired sensor.
+          var session = _activeSessions[athlete.id];
+          if (session == null) {
+            try {
+              session = await dbService.createSession(
+                title: 'Training Session $timestamp',
+                trainingType: 'general',
+                personId: athlete.id,
+              );
+              _activeSessions[athlete.id] = session;
+              debugPrint(
+                  'Late-join session ${session.id} created for ${athlete.name}');
+            } catch (e) {
+              debugPrint('Failed to create late-join session: $e');
+              continue;
             }
-
-            // Store in device-specific history
-            _heartRateHistoryByDevice.putIfAbsent(device.id, () => []);
-            _heartRateHistoryByDevice[device.id]!.add(
-              HeartRateDataPoint(
-                timestamp: DateTime.now(),
-                value: device.currentHeartRate!.toDouble(),
-              ),
-            );
-
-            setState(() {});
           }
+
+          final now = DateTime.now();
+          session.heartRateData.add(HeartRateData(
+            timestamp: now,
+            heartRate: device.currentHeartRate!,
+            deviceId: device.id,
+          ));
+
+          if (device.rrIntervals != null && device.rrIntervals!.isNotEmpty) {
+            HrvService.instance.addRRIntervals(device.id, device.rrIntervals!);
+          }
+
+          _heartRateHistoryByDevice.putIfAbsent(device.id, () => []);
+          _heartRateHistoryByDevice[device.id]!.add(
+            HeartRateDataPoint(
+              timestamp: now,
+              value: device.currentHeartRate!.toDouble(),
+            ),
+          );
         }
+        if (mounted) setState(() {});
       });
-      debugPrint('Timer started');
-      
+      debugPrint('Timer started; $created session(s) active');
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Training session started'),
+          SnackBar(
+            content: Text('Recording $created athlete${created == 1 ? "" : "s"}'),
             backgroundColor: Colors.green,
-            duration: Duration(seconds: 2),
+            duration: const Duration(seconds: 2),
           ),
         );
       }
     } catch (e, stackTrace) {
       debugPrint('ERROR in _startRecording: $e');
       debugPrint('Stack trace: $stackTrace');
-      
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -196,41 +247,61 @@ class _DashboardScreenState extends State<DashboardScreen> {
 
   void _stopRecording() async {
     _recordTimer?.cancel();
+    _recordTimer = null;
 
-    if (_activeSession != null) {
-      final dbService = Provider.of<DatabaseService>(context, listen: false);
-      final bleService = Provider.of<BLEService>(context, listen: false);
-      await dbService.endSession(_activeSession!.id);
+    if (_activeSessions.isEmpty) {
+      setState(() => _isRecording = false);
+      return;
+    }
 
-      // Save HRV snapshot for each assigned athlete
-      for (final device in bleService.connectedDevices) {
-        final athlete = DatabaseService.instance.getAthleteForSensor(device.id);
-        if (athlete != null) {
-          await HrvService.instance.saveSessionHrv(
-            athlete.id,
-            device.id,
-            device.currentHeartRate,
-          );
-        }
-      }
-      HrvService.instance.clearSessionData();
+    final dbService = Provider.of<DatabaseService>(context, listen: false);
+    final bleService = Provider.of<BLEService>(context, listen: false);
 
-      // Sync session to Supabase in background
-      _syncSessionToCloud(_activeSession!);
+    final sessionsSnapshot = _activeSessions.values.toList(growable: false);
+    final athleteCount = sessionsSnapshot.length;
 
-      setState(() {
-        _activeSession = null;
-        _heartRateHistoryByDevice.clear();
-      });
+    // Finalize each session (computes stats, persists endTime).
+    for (final session in sessionsSnapshot) {
+      await dbService.endSession(session.id);
+    }
 
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Training session saved and syncing to cloud...'),
-            duration: Duration(seconds: 2),
-          ),
+    // Save HRV snapshot for each assigned athlete with a worn strap.
+    for (final device in bleService.connectedDevices) {
+      final athlete = DatabaseService.instance.getAthleteForSensor(device.id);
+      if (athlete != null) {
+        await HrvService.instance.saveSessionHrv(
+          athlete.id,
+          device.id,
+          device.currentHeartRate,
         );
       }
+    }
+    HrvService.instance.clearSessionData();
+
+    // Kick off cloud sync per session in background.
+    for (final session in sessionsSnapshot) {
+      // Re-fetch the persisted session so endTime/stats are present.
+      final stored = dbService.getAllSessions().firstWhere(
+            (s) => s.id == session.id,
+            orElse: () => session,
+          );
+      _syncSessionToCloud(stored);
+    }
+
+    setState(() {
+      _isRecording = false;
+      _activeSessions.clear();
+      _heartRateHistoryByDevice.clear();
+    });
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+              'Saved $athleteCount athlete session${athleteCount == 1 ? "" : "s"}, syncing to cloud...'),
+          duration: const Duration(seconds: 2),
+        ),
+      );
     }
   }
 
@@ -475,16 +546,18 @@ class _DashboardScreenState extends State<DashboardScreen> {
       ),
       floatingActionButton: Consumer<BLEService>(
         builder: (context, bleService, child) {
-          final connectedDevices = bleService.connectedDevices.where((d) => d.isConnected).toList();
-          debugPrint('FAB check: _activeSession=${_activeSession != null}, connectedCount=${connectedDevices.length}');
-          
+          final connectedDevices =
+              bleService.connectedDevices.where((d) => d.isConnected).toList();
+          debugPrint(
+              'FAB check: recording=$_isRecording, activeSessions=${_activeSessions.length}, connectedCount=${connectedDevices.length}');
+
           VoidCallback? onPressed;
-          if (_activeSession == null && connectedDevices.isNotEmpty) {
+          if (!_isRecording && connectedDevices.isNotEmpty) {
             onPressed = () {
               debugPrint('Starting recording...');
               _startRecording();
             };
-          } else if (_activeSession != null) {
+          } else if (_isRecording) {
             onPressed = () {
               debugPrint('Stopping recording...');
               _stopRecording();
@@ -492,14 +565,15 @@ class _DashboardScreenState extends State<DashboardScreen> {
           } else {
             debugPrint('FAB disabled: no connected devices');
           }
-          
+
           return FloatingActionButton.extended(
             heroTag: 'dashboard_fab',
             onPressed: onPressed,
-            icon: Icon(_activeSession == null ? Icons.play_arrow : Icons.stop),
-            label: Text(
-                _activeSession == null ? 'Start Training' : 'Stop Training'),
-            backgroundColor: _activeSession == null ? Colors.green : Colors.red,
+            icon: Icon(_isRecording ? Icons.stop : Icons.play_arrow),
+            label: Text(_isRecording
+                ? 'Stop Training (${_activeSessions.length})'
+                : 'Start Training'),
+            backgroundColor: _isRecording ? Colors.red : Colors.green,
           );
         },
       ),
@@ -776,7 +850,23 @@ class _DashboardScreenState extends State<DashboardScreen> {
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(6)),
       child: InkWell(
         borderRadius: BorderRadius.circular(6),
-        onTap: () => _showSensorAssignmentDialog(context, device, athlete),
+        onTap: () {
+          // Daily action: tap → start readiness measurement for this athlete.
+          // If the sensor isn't paired yet, fall back to the assignment dialog.
+          if (athlete == null) {
+            _showSensorAssignmentDialog(context, device, athlete);
+            return;
+          }
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => ReadinessScreen(initialAthlete: athlete),
+            ),
+          );
+        },
+        // Long-press = setup action: re-assign or unassign the sensor.
+        onLongPress: () =>
+            _showSensorAssignmentDialog(context, device, athlete),
         child: LayoutBuilder(
           builder: (context, constraints) {
             final h = constraints.maxHeight;

--- a/mobile_app/lib/screens/dashboard_screen.dart
+++ b/mobile_app/lib/screens/dashboard_screen.dart
@@ -1,12 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'dart:async';
+import 'dart:io' show Platform;
+import 'package:permission_handler/permission_handler.dart';
 import '../services/ble_service.dart';
 import '../services/database_service.dart';
 import '../services/supabase_repository.dart';
 import '../models/training_session.dart';
 import '../models/hr_device.dart';
+import '../models/core_temp_device.dart';
 import '../models/person.dart';
+import '../services/core_temp_service.dart';
+import '../services/hrv_service.dart';
+import 'team_readiness_screen.dart';
 
 // Data point for heart rate with timestamp
 class HeartRateDataPoint {
@@ -42,9 +48,12 @@ class _DashboardScreenState extends State<DashboardScreen> {
     
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       try {
-        // Restore previously connected devices
+        // Restore previously connected devices (HR + CoreTemp)
         await bleService.autoReconnectToSavedDevices();
-        
+        final coreTempService =
+            Provider.of<CoreTempService>(context, listen: false);
+        await coreTempService.autoReconnect();
+
         await _checkBluetoothStatus();
         final updatedBleService = Provider.of<BLEService>(context, listen: false);
         await updatedBleService.checkPermissions(); // Check permissions on startup
@@ -117,6 +126,8 @@ class _DashboardScreenState extends State<DashboardScreen> {
       );
       debugPrint('Session created: ${session.id}');
 
+      HrvService.instance.clearSessionData();
+
       setState(() {
         _activeSession = session;
         _heartRateHistoryByDevice.clear();
@@ -137,6 +148,11 @@ class _DashboardScreenState extends State<DashboardScreen> {
             );
 
             _activeSession!.heartRateData.add(hrData);
+
+            // Accumulate RR intervals for HRV analysis
+            if (device.rrIntervals != null && device.rrIntervals!.isNotEmpty) {
+              HrvService.instance.addRRIntervals(device.id, device.rrIntervals!);
+            }
 
             // Store in device-specific history
             _heartRateHistoryByDevice.putIfAbsent(device.id, () => []);
@@ -183,7 +199,21 @@ class _DashboardScreenState extends State<DashboardScreen> {
 
     if (_activeSession != null) {
       final dbService = Provider.of<DatabaseService>(context, listen: false);
+      final bleService = Provider.of<BLEService>(context, listen: false);
       await dbService.endSession(_activeSession!.id);
+
+      // Save HRV snapshot for each assigned athlete
+      for (final device in bleService.connectedDevices) {
+        final athlete = DatabaseService.instance.getAthleteForSensor(device.id);
+        if (athlete != null) {
+          await HrvService.instance.saveSessionHrv(
+            athlete.id,
+            device.id,
+            device.currentHeartRate,
+          );
+        }
+      }
+      HrvService.instance.clearSessionData();
 
       // Sync session to Supabase in background
       _syncSessionToCloud(_activeSession!);
@@ -319,7 +349,9 @@ class _DashboardScreenState extends State<DashboardScreen> {
                       const SizedBox(width: 8),
                       Expanded(
                         child: Text(
-                          'Bluetooth permissions required. On iOS, you must enable Bluetooth permissions in Settings > Privacy & Security > Bluetooth.',
+                          Platform.isAndroid
+                              ? 'Bluetooth permissions required.'
+                              : 'Bluetooth permissions required. Enable in Settings > Privacy & Security > Bluetooth.',
                           style: TextStyle(
                             fontSize: 13,
                             color: Colors.orange.shade700,
@@ -329,17 +361,14 @@ class _DashboardScreenState extends State<DashboardScreen> {
                       ),
                       TextButton(
                         onPressed: () async {
-                          debugPrint('Grant button pressed');
-                          // On iOS, open settings directly since permissions can't be requested programmatically
-                          // For now, just show the guidance message
-                          if (mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                content: Text('Please go to Settings > Privacy & Security > Bluetooth and enable permissions for Linglong HR Monitor.'),
-                                backgroundColor: Colors.blue,
-                                duration: Duration(seconds: 8),
-                              ),
-                            );
+                          if (Platform.isAndroid) {
+                            final granted = await bleService.requestPermissions();
+                            if (!granted && mounted) {
+                              // Permanently denied — open app settings
+                              await openAppSettings();
+                            }
+                          } else {
+                            await openAppSettings();
                           }
                         },
                         child: Text(
@@ -379,11 +408,16 @@ class _DashboardScreenState extends State<DashboardScreen> {
                 ],
               ),
             ),
+          // Team readiness banner
+          _TeamReadinessBanner(),
           // Main content — full-screen grid
           Expanded(
-            child: Consumer<BLEService>(
-              builder: (context, bleService, child) {
-                final connected = bleService.connectedDevices
+            child: Consumer2<BLEService, CoreTempService>(
+              builder: (context, bleService, coreTempService, child) {
+                final hrDevices = bleService.connectedDevices
+                    .where((d) => d.isConnected)
+                    .toList();
+                final tempDevices = coreTempService.connectedDevices
                     .where((d) => d.isConnected)
                     .toList();
 
@@ -416,11 +450,18 @@ class _DashboardScreenState extends State<DashboardScreen> {
                       ),
                       itemCount: totalSlots,
                       itemBuilder: (context, index) {
-                        if (index < connected.length) {
-                          final device = connected[index];
+                        if (index < hrDevices.length) {
+                          final device = hrDevices[index];
                           final athlete = DatabaseService.instance
                               .getAthleteForSensor(device.id);
                           return _buildSquareDeviceCard(device, index + 1, athlete);
+                        }
+                        final tempIndex = index - hrDevices.length;
+                        if (tempIndex < tempDevices.length) {
+                          final device = tempDevices[tempIndex];
+                          final athlete = DatabaseService.instance
+                              .getAthleteForSensor(device.id);
+                          return _buildCoreTempCard(device, index + 1, athlete);
                         }
                         return _buildEmptySlot(index + 1);
                       },
@@ -484,9 +525,250 @@ class _DashboardScreenState extends State<DashboardScreen> {
     );
   }
 
+  Widget _buildCoreTempCard(CoreTempDevice device, int slotNumber, Person? athlete) {
+    final bgColor = _getCoreTempColor(device.coreTemperature);
+    final accentColor = _getColorForMember(slotNumber);
+
+    return Card(
+      elevation: 2,
+      margin: EdgeInsets.zero,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(6)),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(6),
+        onTap: () => _showSensorAssignmentDialogForCoreTemp(context, device, athlete),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final h = constraints.maxHeight;
+            final w = constraints.maxWidth;
+            final nameFontSize = (h * 0.09).clamp(8.0, 16.0);
+            final valueFontSize = (h * 0.30).clamp(20.0, 64.0);
+            final labelFontSize = (h * 0.07).clamp(7.0, 14.0);
+            final iconSize = (h * 0.14).clamp(12.0, 28.0);
+
+            return Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(6),
+                color: bgColor,
+              ),
+              child: Stack(
+                children: [
+                  Positioned(
+                    top: 0, left: 0,
+                    child: Container(
+                      width: w * 0.4,
+                      height: h * 0.3,
+                      decoration: BoxDecoration(
+                        borderRadius: const BorderRadius.only(
+                          topLeft: Radius.circular(6),
+                          bottomRight: Radius.circular(40),
+                        ),
+                        color: accentColor.withValues(alpha: 0.25),
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.symmetric(
+                        horizontal: w * 0.05, vertical: h * 0.05),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Text(
+                          athlete?.name ?? 'Tap to assign',
+                          style: TextStyle(
+                            fontSize: nameFontSize,
+                            color: athlete != null ? Colors.white : Colors.white60,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          textAlign: TextAlign.center,
+                        ),
+                        Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.sensors,
+                                color: Colors.white70, size: iconSize),
+                            FittedBox(
+                              fit: BoxFit.scaleDown,
+                              child: Text(
+                                device.coreTemperature != null
+                                    ? device.coreTemperature!.toStringAsFixed(1)
+                                    : '--',
+                                style: TextStyle(
+                                  fontSize: valueFontSize,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.white,
+                                  height: 1.0,
+                                ),
+                              ),
+                            ),
+                            Text(
+                              '°C core',
+                              style: TextStyle(
+                                fontSize: labelFontSize,
+                                color: Colors.white70,
+                                height: 1.0,
+                              ),
+                            ),
+                          ],
+                        ),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              device.skinTemperature != null
+                                  ? 'skin ${device.skinTemperature!.toStringAsFixed(1)}°'
+                                  : device.qualityLabel,
+                              style: TextStyle(
+                                fontSize: labelFontSize,
+                                color: Colors.white,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                            if (device.batteryLevel != null)
+                              Text(
+                                '🔋${device.batteryLevel}%',
+                                style: TextStyle(
+                                    fontSize: labelFontSize,
+                                    color: Colors.white70),
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Color _getCoreTempColor(double? temp) {
+    if (temp == null) return Colors.grey[600]!;
+    if (temp < 37.2) return const Color(0xFF1E88E5); // normal — blue
+    if (temp < 38.0) return const Color(0xFFFFB300); // elevated — amber
+    return const Color(0xFFE53935);                   // high — red
+  }
+
+  void _showSensorAssignmentDialogForCoreTemp(
+      BuildContext context, CoreTempDevice device, Person? currentAthlete) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Assign CoreTemp Sensor'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Sensor: ${device.name}',
+                style: TextStyle(fontSize: 12, color: Colors.grey[600])),
+            const SizedBox(height: 8),
+            if (currentAthlete != null)
+              Text('Currently assigned to: ${currentAthlete.name}',
+                  style: const TextStyle(
+                      fontSize: 12, fontWeight: FontWeight.w500)),
+            const SizedBox(height: 16),
+            const Text('Assign to:',
+                style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            _buildAthleteListForDevice(device.id),
+          ],
+        ),
+        actions: [
+          if (currentAthlete != null)
+            TextButton(
+              onPressed: () async {
+                await DatabaseService.instance.unassignSensor(device.id);
+                if (context.mounted) Navigator.pop(context);
+                setState(() {});
+              },
+              child: const Text('Unassign', style: TextStyle(color: Colors.red)),
+            ),
+          TextButton(
+            onPressed: () async {
+              final coreTempService =
+                  Provider.of<CoreTempService>(context, listen: false);
+              final msg = await coreTempService.clearPairedHRMs(device);
+              if (context.mounted) {
+                Navigator.pop(context);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(msg)),
+                );
+              }
+            },
+            child: const Text('Clear HRMs',
+                style: TextStyle(color: Colors.orange)),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAthleteListForDevice(String deviceId) {
+    final athletes = DatabaseService.instance.getAthletes();
+    if (athletes.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: Text(
+          'No athletes found. Add athletes in the Team Members tab.',
+          style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+        ),
+      );
+    }
+    return Container(
+      constraints: const BoxConstraints(maxHeight: 300),
+      child: SingleChildScrollView(
+        child: Column(
+          children: athletes.map((athlete) {
+            final isAssigned = athlete.hasSensorAssigned(deviceId);
+            return ListTile(
+              dense: true,
+              leading: CircleAvatar(
+                radius: 16,
+                backgroundColor: _getColorForAthlete(athlete),
+                child: Text(athlete.name[0].toUpperCase(),
+                    style: const TextStyle(color: Colors.white, fontSize: 14)),
+              ),
+              title: Text(athlete.name,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight:
+                        isAssigned ? FontWeight.bold : FontWeight.normal,
+                  )),
+              subtitle: Text('${athlete.age}y, ${athlete.gender}',
+                  style: const TextStyle(fontSize: 11)),
+              trailing: isAssigned
+                  ? const Icon(Icons.check_circle,
+                      color: Colors.green, size: 20)
+                  : null,
+              onTap: () async {
+                await DatabaseService.instance
+                    .assignSensorToAthlete(deviceId, athlete.id);
+                if (context.mounted) Navigator.pop(context);
+                setState(() {});
+              },
+            );
+          }).toList(),
+        ),
+      ),
+    );
+  }
+
   Widget _buildSquareDeviceCard(HRDevice device, int memberNumber, Person? athlete) {
     final zoneColor = _getHeartRateColorByTrainingZone(device.currentHeartRate);
     final accentColor = _getColorForMember(memberNumber);
+    final liveRmssd = HrvService.instance.getLiveRmssd(device.id);
+    final readiness = athlete != null
+        ? HrvService.instance.getReadiness(athlete.id, currentRmssd: liveRmssd)
+        : null;
 
     return Card(
       elevation: 2,
@@ -535,19 +817,37 @@ class _DashboardScreenState extends State<DashboardScreen> {
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        // Athlete name / assign prompt
-                        Text(
-                          athlete?.name ?? 'Tap to assign',
-                          style: TextStyle(
-                            fontSize: nameFontSize,
-                            color: athlete != null
-                                ? Colors.white
-                                : Colors.white60,
-                            fontWeight: FontWeight.w600,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          textAlign: TextAlign.center,
+                        // Athlete name / assign prompt (with readiness dot)
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (readiness != null) ...[
+                              Container(
+                                width: (labelFontSize * 0.8).clamp(5.0, 9.0),
+                                height: (labelFontSize * 0.8).clamp(5.0, 9.0),
+                                decoration: BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: readiness.color,
+                                ),
+                              ),
+                              const SizedBox(width: 3),
+                            ],
+                            Flexible(
+                              child: Text(
+                                athlete?.name ?? 'Tap to assign',
+                                style: TextStyle(
+                                  fontSize: nameFontSize,
+                                  color: athlete != null
+                                      ? Colors.white
+                                      : Colors.white60,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                textAlign: TextAlign.center,
+                              ),
+                            ),
+                          ],
                         ),
 
                         // BPM value — centre, dominant
@@ -579,16 +879,22 @@ class _DashboardScreenState extends State<DashboardScreen> {
                           ],
                         ),
 
-                        // Zone name + battery
+                        // Zone / RMSSD + battery
                         Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
-                            Text(
-                              _getTrainingZoneName(device.currentHeartRate),
-                              style: TextStyle(
-                                fontSize: labelFontSize,
-                                color: Colors.white,
-                                fontWeight: FontWeight.w500,
+                            Flexible(
+                              child: Text(
+                                liveRmssd != null
+                                    ? 'RMSSD ${liveRmssd.toStringAsFixed(0)}ms'
+                                    : _getTrainingZoneName(
+                                        device.currentHeartRate),
+                                style: TextStyle(
+                                  fontSize: labelFontSize,
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                                overflow: TextOverflow.ellipsis,
                               ),
                             ),
                             if (device.batteryLevel != null)
@@ -775,6 +1081,138 @@ class _DashboardScreenState extends State<DashboardScreen> {
   }
 }
 
+// ── Team readiness banner ─────────────────────────────────────────────────────
+
+class _TeamReadinessBanner extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final athletes = DatabaseService.instance.getAthletes();
+    if (athletes.isEmpty) return const SizedBox.shrink();
+
+    final hrv = HrvService.instance;
+    final ids = athletes.map((a) => a.id).toList();
+    final teamAvg = hrv.getTeamAvgReadiness(ids);
+    if (teamAvg == null) return const SizedBox.shrink(); // no baselines yet
+
+    // Team-level acute / chronic fatigue
+    FatigueScore? teamFatigue(int days) {
+      final scores = athletes
+          .map((a) => hrv.getFatigue(a.id, days: days))
+          .whereType<FatigueScore>()
+          .toList();
+      if (scores.isEmpty) return null;
+      final avgR = scores.map((s) => s.windowAvgRmssd).reduce((a, b) => a + b) /
+          scores.length;
+      final avgB =
+          scores.map((s) => s.baseline).reduce((a, b) => a + b) / scores.length;
+      final pct = (avgR / avgB * 100).clamp(0.0, 150.0);
+      final level = pct >= 90
+          ? FatigueLevel.low
+          : pct >= 75
+              ? FatigueLevel.elevated
+              : pct >= 60
+                  ? FatigueLevel.high
+                  : FatigueLevel.veryHigh;
+      return FatigueScore(
+          level: level, windowAvgRmssd: avgR, baseline: avgB, days: days);
+    }
+
+    final acute = teamFatigue(7);
+    final chronic = teamFatigue(28);
+
+    final readiness = ReadinessScore(
+      percent: teamAvg,
+      baseline: 100,
+      currentRmssd: teamAvg,
+    );
+
+    return InkWell(
+      onTap: () => Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => const TeamReadinessScreen()),
+      ),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+          border: Border(
+            bottom: BorderSide(color: Colors.grey.withValues(alpha: 0.15)),
+          ),
+        ),
+        child: Row(
+          children: [
+            // Readiness % pill
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+              decoration: BoxDecoration(
+                color: readiness.color.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: readiness.color.withValues(alpha: 0.4)),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'READINESS',
+                    style: TextStyle(
+                        fontSize: 9,
+                        fontWeight: FontWeight.w700,
+                        letterSpacing: 0.5,
+                        color: readiness.color),
+                  ),
+                  const SizedBox(width: 5),
+                  Text(
+                    '${teamAvg.toStringAsFixed(0)}%',
+                    style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.bold,
+                        color: readiness.color),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 10),
+            // Fatigue chips
+            if (acute != null)
+              _FatigueChip('Acute', acute),
+            if (acute != null && chronic != null)
+              const SizedBox(width: 6),
+            if (chronic != null)
+              _FatigueChip('Chronic', chronic),
+            const Spacer(),
+            Icon(Icons.chevron_right,
+                size: 16, color: Colors.grey[500]),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FatigueChip extends StatelessWidget {
+  final String label;
+  final FatigueScore score;
+  const _FatigueChip(this.label, this.score);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('$label: ',
+            style: TextStyle(fontSize: 11, color: Colors.grey[600])),
+        Text(score.label,
+            style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+                color: score.color)),
+      ],
+    );
+  }
+}
+
+// ── Device dialog ─────────────────────────────────────────────────────────────
+
 class DeviceDialog extends StatefulWidget {
   const DeviceDialog({super.key});
 
@@ -786,25 +1224,20 @@ class _DeviceDialogState extends State<DeviceDialog> {
   final Set<String> _connectingDevices = {};
   bool _bleAvailable = true;
   bool _hasScanned = false;
+  int _selectedTab = 0; // 0 = Heart Rate, 1 = Core Temp
 
   @override
   void initState() {
     super.initState();
-    
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      // Don't reset BLE service - preserve connected devices
       final bleService = Provider.of<BLEService>(context, listen: false);
-      
       await _checkBluetoothAvailability();
-      await bleService.checkPermissions(); // Check permissions on startup
+      await bleService.checkPermissions();
       final error = await bleService.startScan();
       if (error != null && mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(error),
-            backgroundColor: Colors.red,
-            duration: const Duration(seconds: 3),
-          ),
+          SnackBar(content: Text(error), backgroundColor: Colors.red,
+              duration: const Duration(seconds: 3)),
         );
       }
     });
@@ -813,26 +1246,31 @@ class _DeviceDialogState extends State<DeviceDialog> {
   Future<void> _checkBluetoothAvailability() async {
     final bleService = Provider.of<BLEService>(context, listen: false);
     final available = await bleService.isBluetoothAvailable();
-    setState(() {
-      _bleAvailable = available;
-    });
+    if (mounted) setState(() => _bleAvailable = available);
   }
 
   Future<void> _handleRescan() async {
-    final bleService = Provider.of<BLEService>(context, listen: false);
-    final error = await bleService.startScan();
-    if (error != null && mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(error),
-          backgroundColor: Colors.red,
-          duration: const Duration(seconds: 3),
-        ),
-      );
+    setState(() => _hasScanned = true);
+    if (_selectedTab == 0) {
+      final bleService = Provider.of<BLEService>(context, listen: false);
+      final error = await bleService.startScan();
+      if (error != null && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(error), backgroundColor: Colors.red,
+              duration: const Duration(seconds: 3)),
+        );
+      }
+    } else {
+      final coreTempService =
+          Provider.of<CoreTempService>(context, listen: false);
+      final error = await coreTempService.startScan();
+      if (error != null && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(error), backgroundColor: Colors.red,
+              duration: const Duration(seconds: 3)),
+        );
+      }
     }
-    setState(() {
-      _hasScanned = true;
-    });
   }
 
   @override
@@ -841,247 +1279,77 @@ class _DeviceDialogState extends State<DeviceDialog> {
       title: const Text('Bluetooth Devices'),
       content: SizedBox(
         width: double.maxFinite,
-        child: Consumer<BLEService>(
-          builder: (context, bleService, child) {
-            return Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                // Bluetooth availability warning
-                if (!_bleAvailable)
-                  Container(
-                    padding: const EdgeInsets.all(12),
-                    margin: const EdgeInsets.only(bottom: 12),
-                    decoration: BoxDecoration(
-                      color: Colors.red.shade50,
-                      border: Border.all(color: Colors.red.shade300),
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: Row(
-                      children: [
-                        Icon(Icons.error_outline, color: Colors.red.shade700),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            'Bluetooth is not enabled. Please enable Bluetooth in device settings.',
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: Colors.red.shade700,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Bluetooth warning
+            if (!_bleAvailable)
+              Container(
+                padding: const EdgeInsets.all(12),
+                margin: const EdgeInsets.only(bottom: 8),
+                decoration: BoxDecoration(
+                  color: Colors.red.shade50,
+                  border: Border.all(color: Colors.red.shade300),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
                   children: [
-                    Text(
-                      'Connected: ${bleService.connectedDevices.length}/10',
-                      style: const TextStyle(
-                        fontSize: 12,
-                        color: Colors.grey,
+                    Icon(Icons.error_outline, color: Colors.red.shade700),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'Bluetooth is not enabled.',
+                        style: TextStyle(fontSize: 12, color: Colors.red.shade700),
                       ),
                     ),
-                    if (bleService.isScanning)
-                      const SizedBox(
-                        height: 20,
-                        width: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    else
-                      TextButton(
-                        onPressed: _handleRescan,
-                        child: Text(_hasScanned ? 'Rescan' : 'Scan'),
-                      ),
                   ],
                 ),
-                const SizedBox(height: 12),
-                if (bleService.isScanning)
-                  const LinearProgressIndicator()
-                else
-                  const SizedBox(height: 4),
-                const SizedBox(height: 12),
-                Flexible(
-                  child: Column(
-                    children: [
-                      // Discovered devices list
-                      Expanded(
-                        child: bleService.discoveredDevices.isEmpty
-                            ? Center(
-                                child: Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    Icon(
-                                      Icons.bluetooth_disabled,
-                                      size: 48,
-                                      color: Colors.grey[400],
-                                    ),
-                                    const SizedBox(height: 12),
-                                    Text(
-                                      bleService.isScanning
-                                          ? 'Scanning for devices...'
-                                          : _bleAvailable
-                                              ? 'No devices found'
-                                              : 'Bluetooth is disabled',
-                                      style: TextStyle(
-                                        color: Colors.grey[600],
-                                        fontSize: 14,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              )
-                            : ListView.builder(
-                                shrinkWrap: true,
-                                itemCount: bleService.discoveredDevices.length,
-                                itemBuilder: (context, index) {
-                                  final device = bleService.discoveredDevices[index];
-                            final isConnected = device.isConnected;
-                            final isConnecting =
-                                _connectingDevices.contains(device.id);
-
-                            return ListTile(
-                              leading: const Icon(Icons.bluetooth),
-                              title: Text(device.name),
-                              subtitle:
-                                  Text('Signal: ${device.rssi} dBm'),
-                              trailing: isConnected
-                                  ? const Icon(Icons.check, color: Colors.green)
-                                  : bleService.connectedDevices.length >= 10
-                                      ? const Tooltip(
-                                          message: 'Max devices connected',
-                                          child: Icon(Icons.lock, color: Colors.grey),
-                                        )
-                                      : Row(
-                                          mainAxisSize: MainAxisSize.min,
-                                          children: [
-                                            ElevatedButton(
-                                              onPressed: isConnecting
-                                                  ? null
-                                                  : () async {
-                                                      setState(() {
-                                                        _connectingDevices.add(device.id);
-                                                      });
-
-                                                      try {
-                                                        final success = await bleService.connectDevice(device);
-                                                        if (mounted) {
-                                                          if (success) {
-                                                            ScaffoldMessenger.of(context).showSnackBar(
-                                                              SnackBar(content: Text('Connected to ${device.name}')),
-                                                            );
-                                                          } else {
-                                                            ScaffoldMessenger.of(context).showSnackBar(
-                                                              SnackBar(
-                                                                content: Text('Failed to connect to ${device.name}'),
-                                                                backgroundColor: Colors.red,
-                                                              ),
-                                                            );
-                                                          }
-                                                        }
-                                                      } finally {
-                                                        setState(() {
-                                                          _connectingDevices.remove(device.id);
-                                                        });
-                                                      }
-                                                    },
-                                              child: isConnecting
-                                                  ? const SizedBox(
-                                                      height: 16,
-                                                      width: 16,
-                                                      child: CircularProgressIndicator(strokeWidth: 2),
-                                                    )
-                                                  : const Text('Connect'),
-                                            ),
-                                            const SizedBox(width: 0),
-                                          ],
-                                        ),
-                            );
-                                },
-                              ),
-                      ),
-
-                      const SizedBox(height: 8),
-                      // Saved devices (previously connected) - useful when sensor doesn't advertise
-                      FutureBuilder<List<HRDevice>>(
-                        future: Provider.of<BLEService>(context, listen: false).getSavedConnectedDevices(),
-                        builder: (context, snap) {
-                          if (!snap.hasData || snap.data!.isEmpty) return const SizedBox.shrink();
-                          
-                          // Filter out devices that are already discovered or connected
-                          final savedDevices = snap.data!
-                              .where((sd) => !bleService.discoveredDevices.any((d) => d.id == sd.id) &&
-                                            !bleService.connectedDevices.any((d) => d.id == sd.id))
-                              .toList();
-                          
-                          if (savedDevices.isEmpty) return const SizedBox.shrink();
-                          
-                          return Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              const Text('Saved Devices', style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold, color: Colors.grey)),
-                              const SizedBox(height: 6),
-                              SizedBox(
-                                height: (savedDevices.length * 56).toDouble().clamp(0, 200),
-                                child: ListView.builder(
-                                  itemCount: savedDevices.length,
-                                  itemBuilder: (context, i) {
-                                    final sd = savedDevices[i];
-                                    final isConnecting = _connectingDevices.contains(sd.id);
-                                    return ListTile(
-                                      leading: const Icon(Icons.history, color: Colors.grey),
-                                      title: Text(sd.name, style: const TextStyle(fontSize: 12)),
-                                      subtitle: Text(sd.id, style: const TextStyle(fontSize: 10)),
-                                      trailing: ElevatedButton(
-                                        onPressed: isConnecting
-                                            ? null
-                                            : () async {
-                                                setState(() { _connectingDevices.add(sd.id); });
-                                                try {
-                                                  final success = await Provider.of<BLEService>(context, listen: false).connectDevice(sd);
-                                                  if (mounted) {
-                                                    if (success) {
-                                                      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Restored ${sd.name}')));
-                                                    } else {
-                                                      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Failed to restore ${sd.name}'), backgroundColor: Colors.red));
-                                                    }
-                                                  }
-                                                } finally {
-                                                  setState(() { _connectingDevices.remove(sd.id); });
-                                                }
-                                              },
-                                        child: isConnecting ? const SizedBox(height: 16, width: 16, child: CircularProgressIndicator(strokeWidth: 2)) : const Text('Restore', style: TextStyle(fontSize: 11)),
-                                      ),
-                                    );
-                                  },
-                                ),
-                              ),
-                            ],
-                          );
-                        },
-                      ),
-                    ],
-                  ),
+              ),
+            // Tab selector
+            SegmentedButton<int>(
+              segments: const [
+                ButtonSegment(
+                  value: 0,
+                  icon: Icon(Icons.favorite, size: 16),
+                  label: Text('Heart Rate'),
+                ),
+                ButtonSegment(
+                  value: 1,
+                  icon: Icon(Icons.sensors, size: 16),
+                  label: Text('Core Temp'),
                 ),
               ],
-            );
-          },
+              selected: {_selectedTab},
+              onSelectionChanged: (s) {
+                setState(() {
+                  _selectedTab = s.first;
+                  _hasScanned = false;
+                });
+              },
+            ),
+            const SizedBox(height: 8),
+            // Scan row + progress
+            if (_selectedTab == 0)
+              _buildHRPanel()
+            else
+              _buildCoreTempPanel(),
+          ],
         ),
       ),
       actions: [
-        Consumer<BLEService>(
-          builder: (context, bleService, child) {
+        Consumer2<BLEService, CoreTempService>(
+          builder: (context, bleService, coreTempService, child) {
+            final total = bleService.connectedDevices.length +
+                coreTempService.connectedDevices.length;
             return TextButton(
-              onPressed: bleService.connectedDevices.isEmpty
+              onPressed: total == 0
                   ? null
                   : () {
                       showDialog(
                         context: context,
                         builder: (context) => AlertDialog(
-                          title: const Text('Disconnect All Devices?'),
-                          content: Text(
-                            'This will disconnect ${bleService.connectedDevices.length} device(s).',
-                          ),
+                          title: const Text('Disconnect All?'),
+                          content: Text('Disconnect $total device(s)?'),
                           actions: [
                             TextButton(
                               onPressed: () => Navigator.pop(context),
@@ -1090,6 +1358,7 @@ class _DeviceDialogState extends State<DeviceDialog> {
                             TextButton(
                               onPressed: () {
                                 bleService.disconnectAllDevices();
+                                coreTempService.disconnectAll();
                                 Navigator.pop(context);
                               },
                               child: const Text('Disconnect All',
@@ -1108,6 +1377,329 @@ class _DeviceDialogState extends State<DeviceDialog> {
           child: const Text('Close'),
         ),
       ],
+    );
+  }
+
+  Widget _buildHRPanel() {
+    return Consumer<BLEService>(
+      builder: (context, bleService, _) {
+        final connected = bleService.connectedDevices.where((d) => d.isConnected).toList();
+        final available = bleService.discoveredDevices
+            .where((d) => !connected.any((c) => c.id == d.id))
+            .toList();
+
+        return Flexible(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // ── Connected section ──────────────────────────────────────
+                if (connected.isNotEmpty) ...[
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Text('Connected (${connected.length})',
+                        style: TextStyle(
+                            fontSize: 11,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.grey[600])),
+                  ),
+                  ...connected.map((device) {
+                    final isDisconnecting = _connectingDevices.contains('dc:${device.id}');
+                    return ListTile(
+                      dense: true,
+                      contentPadding: const EdgeInsets.symmetric(horizontal: 4),
+                      leading: Icon(Icons.favorite, color: Colors.green[600], size: 20),
+                      title: Text(device.name, style: const TextStyle(fontSize: 13)),
+                      subtitle: device.currentHeartRate != null
+                          ? Text('${device.currentHeartRate} bpm',
+                              style: const TextStyle(fontSize: 11))
+                          : null,
+                      trailing: OutlinedButton(
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: Colors.red,
+                          side: const BorderSide(color: Colors.red),
+                          padding: const EdgeInsets.symmetric(horizontal: 10),
+                          minimumSize: const Size(0, 30),
+                        ),
+                        onPressed: isDisconnecting
+                            ? null
+                            : () async {
+                                setState(() =>
+                                    _connectingDevices.add('dc:${device.id}'));
+                                try {
+                                  await bleService.disconnectDevice(device);
+                                } finally {
+                                  if (mounted) {
+                                    setState(() => _connectingDevices
+                                        .remove('dc:${device.id}'));
+                                  }
+                                }
+                              },
+                        child: isDisconnecting
+                            ? const SizedBox(
+                                height: 14, width: 14,
+                                child: CircularProgressIndicator(strokeWidth: 2))
+                            : const Text('Disconnect',
+                                style: TextStyle(fontSize: 12)),
+                      ),
+                    );
+                  }),
+                  const Divider(height: 16),
+                ],
+                // ── Available / scan section ───────────────────────────────
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text('Available',
+                        style: TextStyle(
+                            fontSize: 11,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.grey[600])),
+                    bleService.isScanning
+                        ? const SizedBox(
+                            height: 18, width: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2))
+                        : TextButton(
+                            onPressed: _handleRescan,
+                            child: Text(_hasScanned ? 'Rescan' : 'Scan',
+                                style: const TextStyle(fontSize: 12))),
+                  ],
+                ),
+                if (bleService.isScanning)
+                  const LinearProgressIndicator()
+                else
+                  const SizedBox(height: 2),
+                if (available.isEmpty)
+                  _emptyState(bleService.isScanning)
+                else
+                  ...available.map((device) {
+                    final isConnecting = _connectingDevices.contains(device.id);
+                    return ListTile(
+                      dense: true,
+                      contentPadding: const EdgeInsets.symmetric(horizontal: 4),
+                      leading: const Icon(Icons.favorite_border, size: 20),
+                      title: Text(device.name, style: const TextStyle(fontSize: 13)),
+                      subtitle: Text('${device.rssi} dBm',
+                          style: const TextStyle(fontSize: 11)),
+                      trailing: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(horizontal: 10),
+                          minimumSize: const Size(0, 30),
+                        ),
+                        onPressed: isConnecting
+                            ? null
+                            : () async {
+                                setState(() =>
+                                    _connectingDevices.add(device.id));
+                                try {
+                                  final ok =
+                                      await bleService.connectDevice(device);
+                                  if (mounted) {
+                                    ScaffoldMessenger.of(context)
+                                        .showSnackBar(SnackBar(
+                                      content: Text(ok
+                                          ? 'Connected to ${device.name}'
+                                          : 'Failed to connect'),
+                                      backgroundColor:
+                                          ok ? null : Colors.red,
+                                    ));
+                                  }
+                                } finally {
+                                  if (mounted) {
+                                    setState(() => _connectingDevices
+                                        .remove(device.id));
+                                  }
+                                }
+                              },
+                        child: isConnecting
+                            ? const SizedBox(
+                                height: 14, width: 14,
+                                child: CircularProgressIndicator(
+                                    strokeWidth: 2))
+                            : const Text('Connect',
+                                style: TextStyle(fontSize: 12)),
+                      ),
+                    );
+                  }),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildCoreTempPanel() {
+    return Consumer<CoreTempService>(
+      builder: (context, coreTempService, _) {
+        final connected = coreTempService.connectedDevices.where((d) => d.isConnected).toList();
+        final available = coreTempService.discoveredDevices
+            .where((d) => !connected.any((c) => c.id == d.id))
+            .toList();
+
+        return Flexible(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // ── Connected section ──────────────────────────────────────
+                if (connected.isNotEmpty) ...[
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Text('Connected (${connected.length})',
+                        style: TextStyle(
+                            fontSize: 11,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.grey[600])),
+                  ),
+                  ...connected.map((device) {
+                    final isDisconnecting =
+                        _connectingDevices.contains('dc:${device.id}');
+                    return ListTile(
+                      dense: true,
+                      contentPadding: const EdgeInsets.symmetric(horizontal: 4),
+                      leading: Icon(Icons.sensors, color: Colors.green[600], size: 20),
+                      title: Text(device.name, style: const TextStyle(fontSize: 13)),
+                      subtitle: device.coreTemperature != null
+                          ? Text(
+                              '${device.coreTemperature!.toStringAsFixed(1)}°C core',
+                              style: const TextStyle(fontSize: 11))
+                          : null,
+                      trailing: OutlinedButton(
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: Colors.red,
+                          side: const BorderSide(color: Colors.red),
+                          padding: const EdgeInsets.symmetric(horizontal: 10),
+                          minimumSize: const Size(0, 30),
+                        ),
+                        onPressed: isDisconnecting
+                            ? null
+                            : () async {
+                                setState(() => _connectingDevices
+                                    .add('dc:${device.id}'));
+                                try {
+                                  await coreTempService.disconnectDevice(device);
+                                } finally {
+                                  if (mounted) {
+                                    setState(() => _connectingDevices
+                                        .remove('dc:${device.id}'));
+                                  }
+                                }
+                              },
+                        child: isDisconnecting
+                            ? const SizedBox(
+                                height: 14, width: 14,
+                                child: CircularProgressIndicator(strokeWidth: 2))
+                            : const Text('Disconnect',
+                                style: TextStyle(fontSize: 12)),
+                      ),
+                    );
+                  }),
+                  const Divider(height: 16),
+                ],
+                // ── Available / scan section ───────────────────────────────
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text('Available',
+                        style: TextStyle(
+                            fontSize: 11,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.grey[600])),
+                    coreTempService.isScanning
+                        ? const SizedBox(
+                            height: 18, width: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2))
+                        : TextButton(
+                            onPressed: _handleRescan,
+                            child: Text(_hasScanned ? 'Rescan' : 'Scan',
+                                style: const TextStyle(fontSize: 12))),
+                  ],
+                ),
+                if (coreTempService.isScanning)
+                  const LinearProgressIndicator()
+                else
+                  const SizedBox(height: 2),
+                if (available.isEmpty)
+                  _emptyState(coreTempService.isScanning)
+                else
+                  ...available.map((device) {
+                    final isConnecting = _connectingDevices.contains(device.id);
+                    return ListTile(
+                      dense: true,
+                      contentPadding: const EdgeInsets.symmetric(horizontal: 4),
+                      leading: const Icon(Icons.sensors_off, size: 20),
+                      title: Text(device.name, style: const TextStyle(fontSize: 13)),
+                      subtitle: Text('${device.rssi} dBm',
+                          style: const TextStyle(fontSize: 11)),
+                      trailing: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(horizontal: 10),
+                          minimumSize: const Size(0, 30),
+                        ),
+                        onPressed: isConnecting
+                            ? null
+                            : () async {
+                                setState(() =>
+                                    _connectingDevices.add(device.id));
+                                try {
+                                  final ok = await coreTempService
+                                      .connectDevice(device);
+                                  if (mounted) {
+                                    ScaffoldMessenger.of(context)
+                                        .showSnackBar(SnackBar(
+                                      content: Text(ok
+                                          ? 'Connected to ${device.name}'
+                                          : 'Failed to connect'),
+                                      backgroundColor:
+                                          ok ? null : Colors.red,
+                                    ));
+                                  }
+                                } finally {
+                                  if (mounted) {
+                                    setState(() => _connectingDevices
+                                        .remove(device.id));
+                                  }
+                                }
+                              },
+                        child: isConnecting
+                            ? const SizedBox(
+                                height: 14, width: 14,
+                                child: CircularProgressIndicator(
+                                    strokeWidth: 2))
+                            : const Text('Connect',
+                                style: TextStyle(fontSize: 12)),
+                      ),
+                    );
+                  }),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _emptyState(bool isScanning) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.bluetooth_disabled, size: 48, color: Colors.grey[400]),
+          const SizedBox(height: 12),
+          Text(
+            isScanning
+                ? 'Scanning for devices...'
+                : _bleAvailable
+                    ? 'No devices found. Tap Scan to search.'
+                    : 'Bluetooth is disabled',
+            style: TextStyle(color: Colors.grey[600], fontSize: 14),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/mobile_app/lib/screens/profile_screen.dart
+++ b/mobile_app/lib/screens/profile_screen.dart
@@ -5,6 +5,7 @@ import '../services/database_service.dart';
 import '../services/supabase_repository.dart';
 import '../services/settings_service.dart';
 import '../services/sync_service.dart';
+import 'readiness_screen.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
@@ -232,9 +233,6 @@ class _PersonDetailScreenState extends State<PersonDetailScreen> {
             maxHeartRate: newPerson.maxHeartRate,
             restingHeartRate: newPerson.restingHeartRate,
             id: newPerson.id,
-            role: newPerson.role,
-            category: newPerson.category,
-            group: newPerson.group,
           );
         } else {
           // Update existing person
@@ -264,9 +262,6 @@ class _PersonDetailScreenState extends State<PersonDetailScreen> {
             maxHeartRate: widget.person!.maxHeartRate,
             restingHeartRate: widget.person!.restingHeartRate,
             id: widget.person!.id,
-            role: widget.person!.role,
-            category: widget.person!.category,
-            group: widget.person!.group,
           );
         }
 
@@ -560,6 +555,22 @@ class _PersonDetailScreenState extends State<PersonDetailScreen> {
                 ],
               ),
               const SizedBox(height: 24),
+              if (widget.person != null)
+                OutlinedButton.icon(
+                  onPressed: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) =>
+                          ReadinessScreen(initialAthlete: widget.person),
+                    ),
+                  ),
+                  icon: const Icon(Icons.monitor_heart),
+                  label: const Text('Measure Readiness'),
+                  style: OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.all(16),
+                  ),
+                ),
+              const SizedBox(height: 12),
               ElevatedButton(
                 onPressed: _savePerson,
                 style: ElevatedButton.styleFrom(

--- a/mobile_app/lib/screens/profile_screen.dart
+++ b/mobile_app/lib/screens/profile_screen.dart
@@ -22,6 +22,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
         title: null,
         actions: [
           IconButton(
+            icon: const Icon(Icons.monitor_heart),
+            tooltip: 'Measure Readiness',
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const ReadinessScreen()),
+            ),
+          ),
+          IconButton(
             icon: const Icon(Icons.sync),
             onPressed: () => _showSyncDialog(context),
           ),

--- a/mobile_app/lib/screens/readiness_screen.dart
+++ b/mobile_app/lib/screens/readiness_screen.dart
@@ -1,0 +1,691 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/hr_device.dart';
+import '../models/person.dart';
+import '../services/ble_service.dart';
+import '../services/database_service.dart';
+import '../services/hrv_service.dart';
+import '../utils/hrv_analysis.dart';
+
+/// Resting HRV readiness measurement screen.
+/// Flow: Setup → Measurement (countdown + live RR capture) → Results + Feeling score
+class ReadinessScreen extends StatefulWidget {
+  /// Pre-select athlete if launched from a profile row.
+  final Person? initialAthlete;
+
+  const ReadinessScreen({super.key, this.initialAthlete});
+
+  @override
+  State<ReadinessScreen> createState() => _ReadinessScreenState();
+}
+
+enum _Phase { setup, measuring, results }
+
+class _ReadinessScreenState extends State<ReadinessScreen> {
+  _Phase _phase = _Phase.setup;
+
+  // Setup choices
+  Person? _selectedAthlete;
+  HRDevice? _selectedSensor;
+  int _durationMinutes = 3; // default 3 min per Kubios standard
+
+  // Measurement state
+  Timer? _countdownTimer;
+  int _remainingSeconds = 0;
+  final List<int> _accumulatedRR = [];
+  List<int> _lastKnownRR = [];
+  int? _liveHR;
+
+  // Results
+  HrvResult? _result;
+  int? _feelingScore; // 1–5
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedAthlete = widget.initialAthlete;
+  }
+
+  @override
+  void dispose() {
+    _countdownTimer?.cancel();
+    super.dispose();
+  }
+
+  // ── Measurement logic ──────────────────────────────────────────────────────
+
+  void _startMeasurement() {
+    if (_selectedAthlete == null || _selectedSensor == null) return;
+    _accumulatedRR.clear();
+    _lastKnownRR.clear();
+
+    setState(() {
+      _phase = _Phase.measuring;
+      _remainingSeconds = _durationMinutes * 60;
+    });
+
+    _countdownTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      final bleService = Provider.of<BLEService>(context, listen: false);
+      // Find the sensor — it may have new RR data each tick
+      final device = bleService.connectedDevices
+          .firstWhere((d) => d.id == _selectedSensor!.id,
+              orElse: () => _selectedSensor!);
+
+      // Accumulate new RR intervals (avoid double-counting duplicates)
+      if (device.rrIntervals != null && device.rrIntervals!.isNotEmpty) {
+        if (!_listEquals(device.rrIntervals!, _lastKnownRR)) {
+          _lastKnownRR = List<int>.from(device.rrIntervals!);
+          _accumulatedRR.addAll(device.rrIntervals!);
+        }
+      }
+
+      setState(() {
+        _liveHR = device.currentHeartRate;
+        _remainingSeconds--;
+      });
+
+      if (_remainingSeconds <= 0) {
+        timer.cancel();
+        _finishMeasurement();
+      }
+    });
+  }
+
+  void _finishMeasurement() {
+    _countdownTimer?.cancel();
+    if (_accumulatedRR.length < 20) {
+      // Too few intervals — go back to setup with error
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content: Text(
+              'Not enough RR data. Make sure the sensor supports HRV and is worn correctly.'),
+          backgroundColor: Colors.orange,
+        ));
+        setState(() => _phase = _Phase.setup);
+      }
+      return;
+    }
+
+    final result = HrvAnalysis.analyze(_accumulatedRR);
+    setState(() {
+      _result = result;
+      _phase = _Phase.results;
+    });
+  }
+
+  Future<void> _saveResult() async {
+    if (_result == null || _selectedAthlete == null || _selectedSensor == null) {
+      return;
+    }
+    // Save HRV snapshot via HrvService
+    await HrvService.instance.saveReadinessSnapshot(
+      personId: _selectedAthlete!.id,
+      deviceId: _selectedSensor!.id,
+      rrIntervals: _accumulatedRR,
+      restingHR: _liveHR,
+      feelingScore: _feelingScore,
+    );
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+        content: Text('Readiness measurement saved'),
+        backgroundColor: Colors.green,
+      ));
+      Navigator.pop(context);
+    }
+  }
+
+  // ── Build ──────────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Readiness Measurement'),
+        leading: _phase == _Phase.measuring
+            ? const SizedBox.shrink() // disable back during measurement
+            : null,
+      ),
+      body: switch (_phase) {
+        _Phase.setup => _buildSetup(),
+        _Phase.measuring => _buildMeasuring(),
+        _Phase.results => _buildResults(),
+      },
+    );
+  }
+
+  // ── Setup phase ────────────────────────────────────────────────────────────
+
+  Widget _buildSetup() {
+    final athletes = DatabaseService.instance.getAthletes();
+    final bleService = Provider.of<BLEService>(context);
+    final connectedSensors =
+        bleService.connectedDevices.where((d) => d.isConnected).toList();
+
+    return ListView(
+      padding: const EdgeInsets.all(20),
+      children: [
+        // Instructions card
+        Card(
+          color: Theme.of(context).colorScheme.primaryContainer,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(children: [
+                  Icon(Icons.info_outline,
+                      color: Theme.of(context).colorScheme.primary),
+                  const SizedBox(width: 8),
+                  Text('Instructions',
+                      style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: Theme.of(context).colorScheme.primary)),
+                ]),
+                const SizedBox(height: 8),
+                const Text(
+                  '1. Sit or lie still and relax\n'
+                  '2. Breathe normally — do not control your breathing\n'
+                  '3. Wear the chest strap snugly and make sure it is reading\n'
+                  '4. Measure at the same time each day (ideally morning)',
+                  style: TextStyle(fontSize: 13, height: 1.6),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 24),
+
+        // Athlete selection
+        Text('Athlete',
+            style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: 8),
+        if (athletes.isEmpty)
+          const Text('No athletes. Add athletes in the Profile tab.',
+              style: TextStyle(color: Colors.grey))
+        else
+          DropdownButtonFormField<Person>(
+            value: _selectedAthlete,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              contentPadding:
+                  EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            ),
+            hint: const Text('Select athlete'),
+            items: athletes
+                .map((a) => DropdownMenuItem(
+                      value: a,
+                      child: Text(a.name),
+                    ))
+                .toList(),
+            onChanged: (a) => setState(() => _selectedAthlete = a),
+          ),
+        const SizedBox(height: 20),
+
+        // Sensor selection
+        Text('Heart Rate Sensor',
+            style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: 8),
+        if (connectedSensors.isEmpty)
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.orange),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(children: [
+              const Icon(Icons.warning_amber, color: Colors.orange, size: 18),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text(
+                  'No sensors connected. Connect a chest strap in the Dashboard.',
+                  style: TextStyle(fontSize: 13),
+                ),
+              ),
+            ]),
+          )
+        else
+          DropdownButtonFormField<HRDevice>(
+            value: _selectedSensor != null &&
+                    connectedSensors.any((d) => d.id == _selectedSensor!.id)
+                ? connectedSensors
+                    .firstWhere((d) => d.id == _selectedSensor!.id)
+                : null,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              contentPadding:
+                  EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            ),
+            hint: const Text('Select sensor'),
+            items: connectedSensors
+                .map((d) => DropdownMenuItem(
+                      value: d,
+                      child: Text(d.name),
+                    ))
+                .toList(),
+            onChanged: (d) => setState(() => _selectedSensor = d),
+          ),
+        const SizedBox(height: 20),
+
+        // Duration selection
+        Text('Measurement Duration',
+            style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: 8),
+        SegmentedButton<int>(
+          segments: const [
+            ButtonSegment(value: 1, label: Text('1 min')),
+            ButtonSegment(value: 2, label: Text('2 min')),
+            ButtonSegment(value: 3, label: Text('3 min')),
+          ],
+          selected: {_durationMinutes},
+          onSelectionChanged: (s) =>
+              setState(() => _durationMinutes = s.first),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          _durationMinutes == 3
+              ? 'Recommended — gives best HRV accuracy'
+              : _durationMinutes == 2
+                  ? 'Good — acceptable for daily tracking'
+                  : 'Short — minimum for a rough estimate',
+          style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+        ),
+        const SizedBox(height: 32),
+
+        // Start button
+        FilledButton.icon(
+          onPressed: (_selectedAthlete != null && _selectedSensor != null)
+              ? _startMeasurement
+              : null,
+          icon: const Icon(Icons.play_arrow),
+          label: const Text('Start Measurement'),
+          style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(48)),
+        ),
+      ],
+    );
+  }
+
+  // ── Measuring phase ────────────────────────────────────────────────────────
+
+  Widget _buildMeasuring() {
+    final totalSeconds = _durationMinutes * 60;
+    final elapsed = totalSeconds - _remainingSeconds;
+    final progress = elapsed / totalSeconds;
+    final mins = _remainingSeconds ~/ 60;
+    final secs = _remainingSeconds % 60;
+    final rrCount = _accumulatedRR.length;
+    final liveRmssd = rrCount >= 20
+        ? HrvAnalysis.rmssd(_accumulatedRR)
+        : null;
+
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            _selectedAthlete!.name,
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Stay still and breathe normally',
+            style: TextStyle(color: Colors.grey[600], fontSize: 14),
+          ),
+          const SizedBox(height: 40),
+
+          // Countdown ring
+          SizedBox(
+            width: 200,
+            height: 200,
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                SizedBox.expand(
+                  child: CircularProgressIndicator(
+                    value: progress,
+                    strokeWidth: 10,
+                    backgroundColor: Colors.grey[200],
+                    color: _progressColor(progress),
+                  ),
+                ),
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      '${mins.toString().padLeft(2, '0')}:${secs.toString().padLeft(2, '0')}',
+                      style: const TextStyle(
+                          fontSize: 48, fontWeight: FontWeight.bold),
+                    ),
+                    const Text('remaining',
+                        style: TextStyle(color: Colors.grey)),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 32),
+
+          // Live stats
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              _LiveStatCard(
+                label: 'Heart Rate',
+                value: _liveHR != null ? '${_liveHR!} bpm' : '--',
+                icon: Icons.favorite,
+              ),
+              _LiveStatCard(
+                label: 'RMSSD',
+                value: liveRmssd != null
+                    ? '${liveRmssd.toStringAsFixed(1)} ms'
+                    : '...',
+                icon: Icons.show_chart,
+              ),
+              _LiveStatCard(
+                label: 'RR collected',
+                value: '$rrCount',
+                icon: Icons.timeline,
+              ),
+            ],
+          ),
+          const SizedBox(height: 32),
+
+          TextButton(
+            onPressed: () {
+              _countdownTimer?.cancel();
+              setState(() => _phase = _Phase.setup);
+            },
+            child: const Text('Cancel', style: TextStyle(color: Colors.grey)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _progressColor(double progress) {
+    if (progress < 0.5) return Colors.orange;
+    if (progress < 0.8) return Colors.lightBlue;
+    return Colors.green;
+  }
+
+  // ── Results phase ──────────────────────────────────────────────────────────
+
+  Widget _buildResults() {
+    final r = _result!;
+    final qualityPct =
+        (min(r.validIntervals, 500) / 500 * 100).clamp(0.0, 100.0);
+    final baseline = _selectedAthlete != null
+        ? HrvService.instance.getBaseline(_selectedAthlete!.id)
+        : null;
+    final readinessPct = (baseline != null && baseline > 0)
+        ? (r.rmssd / baseline * 100).clamp(0.0, 150.0)
+        : null;
+
+    return ListView(
+      padding: const EdgeInsets.all(20),
+      children: [
+        // Header card
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                Text(_selectedAthlete!.name,
+                    style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 4),
+                Text(
+                  '${_durationMinutes} min measurement · ${r.validIntervals} RR intervals',
+                  style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                ),
+                if (readinessPct != null) ...[
+                  const SizedBox(height: 12),
+                  _ReadinessBadge(readinessPct),
+                ],
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+
+        // HRV metrics grid
+        GridView.count(
+          crossAxisCount: 2,
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          crossAxisSpacing: 10,
+          mainAxisSpacing: 10,
+          childAspectRatio: 2.2,
+          children: [
+            _MetricCard(label: 'RMSSD', value: '${r.rmssd.toStringAsFixed(1)} ms',
+                subtitle: 'Parasympathetic activity'),
+            _MetricCard(label: 'SDNN', value: '${r.sdnn.toStringAsFixed(1)} ms',
+                subtitle: 'Overall HRV'),
+            _MetricCard(label: 'pNN50', value: '${r.pnn50.toStringAsFixed(1)}%',
+                subtitle: 'Vagal tone'),
+            _MetricCard(label: 'Mean RR', value: '${r.meanRR.toStringAsFixed(0)} ms',
+                subtitle: '≈ ${(60000 / r.meanRR).toStringAsFixed(0)} bpm rest'),
+            _MetricCard(
+                label: 'SD1',
+                value: '${r.sd1.toStringAsFixed(1)} ms',
+                subtitle: 'Short-term variability'),
+            _MetricCard(
+                label: 'Quality',
+                value: '${qualityPct.toStringAsFixed(0)}%',
+                subtitle: '${r.validIntervals} valid intervals'),
+          ],
+        ),
+        const SizedBox(height: 20),
+
+        // Feeling score
+        Text('How do you feel today?',
+            style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: 8),
+        Text(
+          _selectedAthlete!.name,
+          style: TextStyle(fontSize: 13, color: Colors.grey[600]),
+        ),
+        const SizedBox(height: 10),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: List.generate(5, (i) {
+            final score = i + 1;
+            final labels = ['Very Bad', 'Bad', 'OK', 'Good', 'Very Good'];
+            final emojis = ['😞', '😕', '😐', '🙂', '😄'];
+            final selected = _feelingScore == score;
+            return GestureDetector(
+              onTap: () => setState(() => _feelingScore = score),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 150),
+                padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 6),
+                decoration: BoxDecoration(
+                  color: selected
+                      ? Theme.of(context)
+                          .colorScheme
+                          .primaryContainer
+                      : Colors.transparent,
+                  borderRadius: BorderRadius.circular(10),
+                  border: selected
+                      ? Border.all(
+                          color: Theme.of(context).colorScheme.primary,
+                          width: 2)
+                      : Border.all(color: Colors.transparent),
+                ),
+                child: Column(
+                  children: [
+                    Text(emojis[i], style: const TextStyle(fontSize: 26)),
+                    const SizedBox(height: 2),
+                    Text(labels[i],
+                        style: TextStyle(
+                            fontSize: 10,
+                            color: selected
+                                ? Theme.of(context).colorScheme.primary
+                                : Colors.grey[600],
+                            fontWeight: selected
+                                ? FontWeight.bold
+                                : FontWeight.normal)),
+                  ],
+                ),
+              ),
+            );
+          }),
+        ),
+        const SizedBox(height: 28),
+
+        // Save button
+        FilledButton.icon(
+          onPressed: _saveResult,
+          icon: const Icon(Icons.save),
+          label: const Text('Save Result'),
+          style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(48)),
+        ),
+        const SizedBox(height: 8),
+        TextButton(
+          onPressed: () => setState(() {
+            _phase = _Phase.setup;
+            _result = null;
+            _feelingScore = null;
+          }),
+          child: const Text('Measure Again'),
+        ),
+      ],
+    );
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  bool _listEquals(List<int> a, List<int> b) {
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}
+
+// ── Small widgets ─────────────────────────────────────────────────────────────
+
+class _LiveStatCard extends StatelessWidget {
+  final String label;
+  final String value;
+  final IconData icon;
+
+  const _LiveStatCard(
+      {required this.label, required this.value, required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Icon(icon, size: 18, color: Colors.grey[600]),
+        const SizedBox(height: 4),
+        Text(value,
+            style: const TextStyle(
+                fontSize: 16, fontWeight: FontWeight.bold)),
+        Text(label,
+            style: TextStyle(fontSize: 11, color: Colors.grey[600])),
+      ],
+    );
+  }
+}
+
+class _MetricCard extends StatelessWidget {
+  final String label;
+  final String value;
+  final String subtitle;
+
+  const _MetricCard(
+      {required this.label, required this.value, required this.subtitle});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(label,
+                style: TextStyle(
+                    fontSize: 11,
+                    color: Colors.grey[600],
+                    fontWeight: FontWeight.w500)),
+            Text(value,
+                style: const TextStyle(
+                    fontSize: 18, fontWeight: FontWeight.bold)),
+            Text(subtitle,
+                style: TextStyle(fontSize: 10, color: Colors.grey[500]),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReadinessBadge extends StatelessWidget {
+  final double pct;
+
+  const _ReadinessBadge(this.pct);
+
+  Color get _color {
+    if (pct >= 90) return Colors.green;
+    if (pct >= 75) return Colors.lightBlue;
+    if (pct >= 60) return Colors.orange;
+    return Colors.red;
+  }
+
+  String get _label {
+    if (pct >= 90) return 'High Readiness';
+    if (pct >= 75) return 'Normal';
+    if (pct >= 60) return 'Reduced';
+    return 'Low Readiness';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: _color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: _color.withValues(alpha: 0.4)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '${pct.toStringAsFixed(0)}%',
+            style: TextStyle(
+                fontSize: 22,
+                fontWeight: FontWeight.bold,
+                color: _color),
+          ),
+          const SizedBox(width: 8),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Readiness',
+                  style: TextStyle(
+                      fontSize: 10,
+                      color: _color,
+                      fontWeight: FontWeight.w600)),
+              Text(_label,
+                  style: TextStyle(
+                      fontSize: 12,
+                      color: _color,
+                      fontWeight: FontWeight.bold)),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/services/database_service.dart
+++ b/mobile_app/lib/services/database_service.dart
@@ -150,21 +150,27 @@ class DatabaseService extends ChangeNotifier {
   Future<TrainingSession> createSession({
     required String title,
     required String trainingType,
+    String? personId,
     String? notes,
   }) async {
-    // Ensure a person is selected - auto-select first one if none selected
-    if (_currentPerson == null) {
-      final persons = getAllPersons();
-      if (persons.isEmpty) {
-        throw Exception('Please create a person profile first');
+    // Resolve target person: explicit param wins, else fall back to _currentPerson,
+    // else auto-select the first person in the box.
+    String? targetPersonId = personId;
+    if (targetPersonId == null) {
+      if (_currentPerson == null) {
+        final persons = getAllPersons();
+        if (persons.isEmpty) {
+          throw Exception('Please create a person profile first');
+        }
+        _currentPerson = persons.first;
+        debugPrint('Auto-selected person: ${_currentPerson!.name}');
       }
-      _currentPerson = persons.first;
-      debugPrint('Auto-selected person: ${_currentPerson!.name}');
+      targetPersonId = _currentPerson!.id;
     }
 
     final session = TrainingSession(
       id: const Uuid().v4(),
-      personId: _currentPerson!.id,
+      personId: targetPersonId,
       title: title,
       startTime: DateTime.now(),
       duration: 0,
@@ -173,7 +179,7 @@ class DatabaseService extends ChangeNotifier {
       synced: false,
       notes: notes,
     );
-    
+
     await _sessionBox!.put(session.id, session);
     notifyListeners();
     return session;
@@ -196,15 +202,17 @@ class DatabaseService extends ChangeNotifier {
         session.avgHeartRate = heartRates.reduce((a, b) => a + b) ~/ heartRates.length;
         session.maxHeartRate = heartRates.reduce((a, b) => a > b ? a : b);
         session.minHeartRate = heartRates.reduce((a, b) => a < b ? a : b);
-        
-        // Simple calorie calculation (can be improved)
-        if (_currentPerson != null) {
+
+        // Calorie calc uses the session's own person (not _currentPerson)
+        // so multi-athlete recordings get correct per-person calories.
+        final sessionPerson = _personBox?.get(session.personId) ?? _currentPerson;
+        if (sessionPerson != null) {
           session.calories = _calculateCalories(
             avgHeartRate: session.avgHeartRate!,
             duration: session.duration,
-            weight: _currentPerson!.weight,
-            age: _currentPerson!.age,
-            gender: _currentPerson!.gender,
+            weight: sessionPerson.weight,
+            age: sessionPerson.age,
+            gender: sessionPerson.gender,
           );
         }
       }

--- a/mobile_app/lib/services/hrv_service.dart
+++ b/mobile_app/lib/services/hrv_service.dart
@@ -1,0 +1,310 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/daily_hrv_snapshot.dart';
+import '../utils/hrv_analysis.dart';
+
+class HrvService extends ChangeNotifier {
+  static final HrvService instance = HrvService._internal();
+  HrvService._internal();
+
+  Box<String>? _box;
+
+  // Accumulated RR intervals per device during an active session.
+  final Map<String, List<int>> _sessionRRByDevice = {};
+
+  // Last-known RR list per device — used to avoid double-counting duplicates.
+  final Map<String, List<int>> _lastKnownRR = {};
+
+  Future<void> init() async {
+    _box = await Hive.openBox<String>('hrv_snapshots');
+  }
+
+  // ── Session accumulation ──────────────────────────────────────────────────
+
+  /// Call this each timer tick with the device's current rrIntervals list.
+  /// Only appends if the list has changed since the last call.
+  void addRRIntervals(String deviceId, List<int> intervals) {
+    if (intervals.isEmpty) return;
+    final last = _lastKnownRR[deviceId];
+    if (last != null && _listEquals(last, intervals)) return; // no new data
+    _lastKnownRR[deviceId] = List<int>.from(intervals);
+    _sessionRRByDevice.putIfAbsent(deviceId, () => []);
+    _sessionRRByDevice[deviceId]!.addAll(intervals);
+  }
+
+  void clearSessionData() {
+    _sessionRRByDevice.clear();
+    _lastKnownRR.clear();
+  }
+
+  List<int> getSessionRR(String deviceId) =>
+      _sessionRRByDevice[deviceId] ?? [];
+
+  /// Live RMSSD from accumulated session RR intervals.
+  /// Returns null if fewer than 50 intervals have been collected.
+  double? getLiveRmssd(String deviceId) {
+    final rr = getSessionRR(deviceId);
+    if (rr.length < 50) return null;
+    final val = HrvAnalysis.rmssd(rr);
+    return val > 0 ? val : null;
+  }
+
+  // ── Snapshot persistence ──────────────────────────────────────────────────
+
+  /// Compute HRV from accumulated session data and persist a snapshot.
+  Future<void> saveSessionHrv(
+      String personId, String deviceId, int? restingHR) async {
+    if (_box == null) return;
+    final rr = getSessionRR(deviceId);
+    if (rr.length < 50) return;
+    final result = HrvAnalysis.analyze(rr);
+    if (result.rmssd <= 0) return;
+
+    final snapshot = DailyHrvSnapshot(
+      id: const Uuid().v4(),
+      personId: personId,
+      timestamp: DateTime.now(),
+      rmssd: result.rmssd,
+      sdnn: result.sdnn,
+      meanRR: result.meanRR,
+      restingHR: restingHR,
+      sampleCount: result.validIntervals,
+    );
+
+    await _box!.put(snapshot.id, jsonEncode(snapshot.toJson()));
+    notifyListeners();
+  }
+
+  /// Save a dedicated readiness measurement snapshot (from the readiness screen).
+  /// Accepts the raw [rrIntervals] directly rather than pulling from session state.
+  Future<void> saveReadinessSnapshot({
+    required String personId,
+    required String deviceId,
+    required List<int> rrIntervals,
+    int? restingHR,
+    int? feelingScore,
+  }) async {
+    if (_box == null) return;
+    if (rrIntervals.length < 20) return;
+    final result = HrvAnalysis.analyze(rrIntervals);
+    if (result.rmssd <= 0) return;
+
+    final snapshot = DailyHrvSnapshot(
+      id: const Uuid().v4(),
+      personId: personId,
+      timestamp: DateTime.now(),
+      rmssd: result.rmssd,
+      sdnn: result.sdnn,
+      meanRR: result.meanRR,
+      restingHR: restingHR,
+      sampleCount: result.validIntervals,
+    );
+
+    await _box!.put(snapshot.id, jsonEncode(snapshot.toJson()));
+    notifyListeners();
+  }
+
+  // ── Query ─────────────────────────────────────────────────────────────────
+
+  List<DailyHrvSnapshot> getSnapshots(String personId, {int days = 60}) {
+    if (_box == null) return [];
+    final cutoff = DateTime.now().subtract(Duration(days: days));
+    final results = <DailyHrvSnapshot>[];
+    for (final raw in _box!.values) {
+      try {
+        final s = DailyHrvSnapshot.fromJson(jsonDecode(raw));
+        if (s.personId == personId && s.timestamp.isAfter(cutoff)) {
+          results.add(s);
+        }
+      } catch (_) {}
+    }
+    results.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    return results;
+  }
+
+  /// Rolling baseline RMSSD from last 60 days. Returns null if fewer than
+  /// 3 snapshots exist (not enough data to establish a baseline).
+  double? getBaseline(String personId) {
+    final snapshots = getSnapshots(personId, days: 60);
+    if (snapshots.length < 3) return null;
+    return snapshots.map((s) => s.rmssd).reduce((a, b) => a + b) /
+        snapshots.length;
+  }
+
+  /// Readiness score relative to personal baseline.
+  /// Pass [currentRmssd] to override with a live value (e.g. from an
+  /// ongoing session); otherwise the most recent stored snapshot is used.
+  ReadinessScore? getReadiness(String personId, {double? currentRmssd}) {
+    final baseline = getBaseline(personId);
+    if (baseline == null || baseline <= 0) return null;
+
+    double? rmssd = currentRmssd;
+    if (rmssd == null) {
+      final recent = getSnapshots(personId, days: 1);
+      rmssd = recent.isEmpty ? null : recent.last.rmssd;
+    }
+    if (rmssd == null) return null;
+
+    final percent = (rmssd / baseline * 100).clamp(0.0, 150.0);
+    return ReadinessScore(
+        percent: percent, baseline: baseline, currentRmssd: rmssd);
+  }
+
+  // ── Fatigue ───────────────────────────────────────────────────────────────
+
+  /// Acute fatigue (default 7-day) or chronic fatigue (28-day).
+  /// Lower recent RMSSD vs baseline = higher fatigue.
+  FatigueScore? getFatigue(String personId, {int days = 7}) {
+    final baseline = getBaseline(personId);
+    if (baseline == null || baseline <= 0) return null;
+    final snapshots = getSnapshots(personId, days: days);
+    if (snapshots.isEmpty) return null;
+
+    final avg = snapshots.map((s) => s.rmssd).reduce((a, b) => a + b) /
+        snapshots.length;
+    final pct = (avg / baseline * 100).clamp(0.0, 150.0);
+
+    final level = pct >= 90
+        ? FatigueLevel.low
+        : pct >= 75
+            ? FatigueLevel.elevated
+            : pct >= 60
+                ? FatigueLevel.high
+                : FatigueLevel.veryHigh;
+
+    return FatigueScore(
+        level: level, windowAvgRmssd: avg, baseline: baseline, days: days);
+  }
+
+  // ── Team summary ──────────────────────────────────────────────────────────
+
+  /// Average readiness % across all athletes that have a baseline.
+  double? getTeamAvgReadiness(List<String> personIds) {
+    final scores = personIds
+        .map((id) => getReadiness(id))
+        .whereType<ReadinessScore>()
+        .toList();
+    if (scores.isEmpty) return null;
+    return scores.map((s) => s.percent).reduce((a, b) => a + b) /
+        scores.length;
+  }
+
+  // ── Manual snapshot (morning HRV) ─────────────────────────────────────────
+
+  /// Persist a snapshot computed externally (e.g. morning measurement screen).
+  Future<void> saveDirectSnapshot(DailyHrvSnapshot snapshot) async {
+    if (_box == null) return;
+    await _box!.put(snapshot.id, jsonEncode(snapshot.toJson()));
+    notifyListeners();
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  bool _listEquals(List<int> a, List<int> b) {
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}
+
+// ── Fatigue model ─────────────────────────────────────────────────────────────
+
+enum FatigueLevel { low, elevated, high, veryHigh }
+
+class FatigueScore {
+  final FatigueLevel level;
+  final double windowAvgRmssd; // avg RMSSD for the window period
+  final double baseline;       // 60-day RMSSD baseline
+  final int days;              // window size (7 = acute, 28 = chronic)
+
+  const FatigueScore({
+    required this.level,
+    required this.windowAvgRmssd,
+    required this.baseline,
+    required this.days,
+  });
+
+  /// windowAvgRmssd as % of baseline (higher = less fatigued).
+  double get percent => (windowAvgRmssd / baseline * 100).clamp(0.0, 150.0);
+
+  Color get color {
+    switch (level) {
+      case FatigueLevel.low:
+        return const Color(0xFF1E88E5); // blue
+      case FatigueLevel.elevated:
+        return const Color(0xFFFFB300); // amber
+      case FatigueLevel.high:
+        return const Color(0xFFF4511E); // deep orange
+      case FatigueLevel.veryHigh:
+        return const Color(0xFFE53935); // red
+    }
+  }
+
+  String get label {
+    switch (level) {
+      case FatigueLevel.low:
+        return 'Low';
+      case FatigueLevel.elevated:
+        return 'Elevated';
+      case FatigueLevel.high:
+        return 'High';
+      case FatigueLevel.veryHigh:
+        return 'Very High';
+    }
+  }
+}
+
+// ── Readiness model ───────────────────────────────────────────────────────────
+
+enum ReadinessZone { veryLow, low, normal, high }
+
+class ReadinessScore {
+  final double percent;      // 0–150 (100 = exactly at baseline)
+  final double baseline;     // personal RMSSD baseline (ms)
+  final double currentRmssd; // current RMSSD (ms)
+
+  const ReadinessScore({
+    required this.percent,
+    required this.baseline,
+    required this.currentRmssd,
+  });
+
+  ReadinessZone get zone {
+    if (percent < 70) return ReadinessZone.veryLow;
+    if (percent < 85) return ReadinessZone.low;
+    if (percent <= 115) return ReadinessZone.normal;
+    return ReadinessZone.high;
+  }
+
+  Color get color {
+    switch (zone) {
+      case ReadinessZone.veryLow:
+        return const Color(0xFFE65100); // deep orange
+      case ReadinessZone.low:
+        return const Color(0xFFFFB300); // amber
+      case ReadinessZone.normal:
+        return const Color(0xFF1E88E5); // blue
+      case ReadinessZone.high:
+        return const Color(0xFF0D47A1); // dark blue
+    }
+  }
+
+  String get label {
+    switch (zone) {
+      case ReadinessZone.veryLow:
+        return 'Very Low';
+      case ReadinessZone.low:
+        return 'Low';
+      case ReadinessZone.normal:
+        return 'Normal';
+      case ReadinessZone.high:
+        return 'High';
+    }
+  }
+}

--- a/supabase/migrations/003_readiness_measurements.sql
+++ b/supabase/migrations/003_readiness_measurements.sql
@@ -1,0 +1,55 @@
+-- Readiness measurements table
+-- Stores dedicated resting HRV measurements taken outside of training sessions.
+-- Each row represents one measurement per athlete per day.
+
+CREATE TABLE IF NOT EXISTS public.readiness_measurements (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  person_id     text NOT NULL,            -- athlete ID (local Hive UUID)
+  device_id     text NOT NULL,            -- BLE sensor ID
+  measured_at   timestamptz NOT NULL DEFAULT now(),
+  duration_sec  int NOT NULL,             -- measurement duration (60/120/180)
+
+  -- Raw data
+  rr_intervals  jsonb NOT NULL,           -- array of RR intervals in ms
+
+  -- HRV metrics
+  rmssd         double precision,         -- ms (primary vagal metric)
+  sdnn          double precision,         -- ms (overall HRV)
+  pnn50         double precision,         -- % (vagal tone)
+  mean_rr       double precision,         -- ms
+  sd1           double precision,         -- Poincaré short-term variability
+  sd2           double precision,         -- Poincaré long-term variability
+
+  -- Derived scores
+  resting_hr    int,                      -- bpm at time of measurement
+  quality_pct   double precision,         -- 0–100, based on valid interval count
+  readiness_pct double precision,         -- 0–150, % of personal baseline RMSSD
+  feeling       smallint                  -- 1 (very bad) – 5 (very good), nullable
+    CHECK (feeling BETWEEN 1 AND 5),
+
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- Row-level security: users only see their own measurements
+ALTER TABLE public.readiness_measurements ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own readiness measurements"
+  ON public.readiness_measurements FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own readiness measurements"
+  ON public.readiness_measurements FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own readiness measurements"
+  ON public.readiness_measurements FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own readiness measurements"
+  ON public.readiness_measurements FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Index for fast per-athlete queries
+CREATE INDEX IF NOT EXISTS idx_readiness_person_date
+  ON public.readiness_measurements (user_id, person_id, measured_at DESC);


### PR DESCRIPTION
## Summary

- **Fixes #22** — Live training session now records every athlete whose paired sensor is worn, instead of capturing only one athlete's data.
- **UX** — Tapping a sensor card on the dashboard starts a readiness measurement for that athlete; long-press opens the existing re-assign dialog.

## What changed

### Multi-athlete recording (#22)

- `dashboard_screen.dart`: replaced single `_activeSession?` with `Map<String, TrainingSession> _activeSessions` keyed by athlete id, plus an `_isRecording` flag.
- `_startRecording` creates one session per worn, paired sensor at start.
- The 1Hz timer fans HR samples per device into the matching athlete's session and **lazily creates a session** if a paired strap starts producing HR mid-session (e.g., athlete puts strap on late, or strap reconnects after a brief drop).
- `_stopRecording` finalizes every active session, runs the existing HRV-snapshot save, and kicks off cloud sync per session.
- FAB shows `Stop Training (N)` while recording, where N is the number of active athlete sessions.

### Backend support

- `DatabaseService.createSession` now accepts an optional `personId`, so callers can target a specific athlete instead of always using `_currentPerson`.
- `DatabaseService.endSession` now looks up the session's own person for calorie calc, so multi-athlete recordings get correct per-person calories.

### UX: tap card → readiness

- Tap on a paired sensor card opens `ReadinessScreen` pre-selected with that athlete (the daily action).
- Long-press opens the existing assignment dialog (re-pairing — a setup action).
- Tapping a sensor with no athlete still opens the assignment dialog (so unpaired cards behave as before).

## Test plan

- [ ] Wear two paired chest straps, tap **Start Training**. Snackbar shows `Recording 2 athletes`. FAB shows `Stop Training (2)`.
- [ ] Tap **Stop Training**. History shows two distinct sessions, one per athlete, each with that athlete's HR data only.
- [ ] Start with one strap worn; put on a second strap mid-session. Confirm the second athlete's session is created lazily and gets recorded.
- [ ] Tap a paired sensor card → Readiness screen opens with that athlete preselected.
- [ ] Long-press a paired sensor card → assignment dialog opens.
- [ ] Tap an unpaired sensor card → assignment dialog opens (unchanged).
- [ ] Calorie totals on each session match the right athlete's weight/age/gender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)