### PR TITLE
Add readiness cloud sync and fix GMT+8 timestamp handling

### DIFF
--- a/docs/superpowers/specs/2026-05-06-readiness-cloud-sync.md
+++ b/docs/superpowers/specs/2026-05-06-readiness-cloud-sync.md
@@ -1,0 +1,131 @@
+# Readiness Cloud Sync Spec
+
+**Date:** 2026-05-06  
+**Status:** Ready for implementation  
+**Relates to:** `docs/superpowers/specs/2026-05-06-hrv-readiness-recording-history.md`
+
+---
+
+## Problem
+
+The mobile sync button (`SyncService.syncAll`) pushes and pulls training sessions but ignores readiness measurements entirely. The web app's Readiness History page reads from the `readiness_measurements` Supabase table, which is always empty because nothing writes to it from the mobile app.
+
+---
+
+## Goal
+
+Add readiness measurements to the existing sync flow so that after tapping sync:
+
+- Local unsynced readiness measurements are uploaded to Supabase.
+- Cloud readiness records are pulled down to local Hive storage.
+
+No new UI is required. The sync button should handle both training sessions and readiness transparently.
+
+---
+
+## Current State
+
+| Layer | Training sessions | Readiness measurements |
+|---|---|---|
+| Local storage | Hive box `training_sessions` | Hive box `readiness_measurements` |
+| `synced` flag tracked | ✅ | ✅ (field exists, never acted on) |
+| `SupabaseRepository` method | `upsertTrainingSession` | ❌ missing |
+| Sync-up in `SyncService` | ✅ via `syncAllUnsyncedSessions` | ❌ missing |
+| Sync-down in `DatabaseService` | ✅ via `syncDownFromCloud` | ❌ missing |
+| Web app reads from Supabase | ✅ | ✅ (but table always empty) |
+
+The Supabase table `readiness_measurements` already exists with the correct schema (migration `003_readiness_measurements.sql`).
+
+---
+
+## Field Mapping
+
+| `ReadinessMeasurement` (Dart) | `readiness_measurements` (Supabase) |
+|---|---|
+| `id` | `id` |
+| `personId` | `person_id` |
+| `deviceId` | `device_id` |
+| `measuredAt` | `measured_at` |
+| `durationSec` | `duration_sec` |
+| `rrIntervals` | `rr_intervals` (jsonb array) |
+| `rmssd` | `rmssd` |
+| `sdnn` | `sdnn` |
+| `pnn50` | `pnn50` |
+| `meanRR` | `mean_rr` |
+| `sd1` | `sd1` |
+| `sd2` | `sd2` |
+| `restingHR` | `resting_hr` |
+| `qualityPct` | `quality_pct` |
+| `readinessPct` | `readiness_pct` |
+| `feelingScore` | `feeling` |
+| _(auth user)_ | `user_id` |
+
+---
+
+## Required Changes
+
+### 1. `SupabaseRepository` — two new methods
+
+**`upsertReadinessMeasurement`**  
+Insert or update one readiness record. Uses `id` as conflict target so repeated syncs are idempotent.
+
+**`fetchReadinessMeasurements`**  
+Fetch all readiness records for the authenticated user, ordered by `measured_at` descending.
+
+### 2. `HrvService` — sync-up helper
+
+Add `syncAllUnsyncedReadiness(SupabaseRepository repo)`:
+- Load all local `ReadinessMeasurement` records where `synced == false`.
+- Call `repo.upsertReadinessMeasurement(...)` for each.
+- On success, overwrite the Hive entry with `synced: true`.
+- Errors per-record should be logged and skipped (same pattern as training sessions).
+
+### 3. `HrvService` — sync-down helper
+
+Add `syncDownReadinessFromCloud(SupabaseRepository repo)`:
+- Call `repo.fetchReadinessMeasurements()`.
+- For each remote record, check if a local record with the same `id` already exists.
+- If missing, insert locally with `synced: true`.
+- Do not overwrite existing local records (local wins on conflict).
+
+### 4. `SyncService._syncOnLogin` — wire it in
+
+After the existing `db.syncDownFromCloud(_repo)` / `db.syncAllUnsyncedSessions(_repo)` calls, add:
+
+```
+await hrv.syncDownReadinessFromCloud(_repo);
+await hrv.syncAllUnsyncedReadiness(_repo);
+```
+
+`HrvService.instance` is accessible the same way `DatabaseService.instance` is used.
+
+---
+
+## Behaviour Spec
+
+| Scenario | Expected result |
+|---|---|
+| Offline sync attempt | Skip silently; local records stay `synced: false` |
+| Record already on cloud (same id) | Upsert is idempotent; no duplicate |
+| Cloud record not in local Hive | Inserted locally as `synced: true` |
+| Sync failure mid-batch | Completed records are marked synced; failed records retry on next sync |
+| Not authenticated | Entire sync is skipped (existing guard in `SyncService`) |
+
+---
+
+## Out of Scope
+
+- Conflict resolution when the same record differs locally and remotely (local wins for now).
+- Deleting cloud records from the mobile app.
+- Syncing `DailyHrvSnapshot` (session-derived HRV) — only dedicated readiness measurements.
+- Any UI changes.
+
+---
+
+## Acceptance Criteria
+
+1. After tapping sync, all local readiness measurements with `synced: false` appear in the Supabase `readiness_measurements` table.
+2. After sync, those records are updated to `synced: true` locally.
+3. Cloud records created on another device (or directly in Supabase) appear in local Hive after sync-down.
+4. The web app Readiness History page shows the synced measurements without any additional changes.
+5. A repeated sync does not create duplicate rows in Supabase.

--- a/mobile_app/lib/screens/dashboard_screen.dart
+++ b/mobile_app/lib/screens/dashboard_screen.dart
@@ -10,6 +10,7 @@ import '../services/supabase_repository.dart';
 import '../models/training_session.dart';
 import '../models/hr_device.dart';
 import '../models/person.dart';
+import '../utils/timezone_utils.dart';
 import 'athlete_detail_screen.dart';
 import 'readiness_screen.dart';
 
@@ -59,7 +60,8 @@ class _DashboardScreenState extends State<DashboardScreen>
         await bleService.autoReconnectToSavedDevices();
 
         await _checkBluetoothStatus();
-        final updatedBleService = Provider.of<BLEService>(context, listen: false);
+        final updatedBleService =
+            Provider.of<BLEService>(context, listen: false);
         await updatedBleService.checkPermissions();
 
         // Only start scanning if permissions are granted and no devices already connected
@@ -87,7 +89,8 @@ class _DashboardScreenState extends State<DashboardScreen>
     _startBleCheckTimer();
   }
 
-  Future<void> _requestBlePermission(BuildContext ctx, BLEService bleService) async {
+  Future<void> _requestBlePermission(
+      BuildContext ctx, BLEService bleService) async {
     // Step 1: check current status before requesting
     final preScan = await Permission.bluetoothScan.status;
     final preConnect = await Permission.bluetoothConnect.status;
@@ -229,7 +232,7 @@ class _DashboardScreenState extends State<DashboardScreen>
 
       HrvService.instance.clearSessionData();
 
-      final timestamp = DateTime.now().toString().substring(0, 16);
+      final timestamp = TimezoneUtils.formatDateTime(DateTime.now());
       int created = 0;
 
       for (final device in bleService.connectedDevices) {
@@ -335,11 +338,12 @@ class _DashboardScreenState extends State<DashboardScreen>
         }
       });
       debugPrint('Timer started; activeSessions=${_activeSessions.length}');
-      
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Recording $created athlete${created == 1 ? '' : 's'}'),
+            content:
+                Text('Recording $created athlete${created == 1 ? '' : 's'}'),
             backgroundColor: Colors.green,
             duration: const Duration(seconds: 2),
           ),
@@ -348,7 +352,7 @@ class _DashboardScreenState extends State<DashboardScreen>
     } catch (e, stackTrace) {
       debugPrint('ERROR in _startRecording: $e');
       debugPrint('Stack trace: $stackTrace');
-      
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -463,7 +467,7 @@ class _DashboardScreenState extends State<DashboardScreen>
         if (!e.toString().contains('_isInitialized')) {
           errorMsg = 'Session saved locally (sync failed)';
         }
-        
+
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(errorMsg),
@@ -487,7 +491,8 @@ class _DashboardScreenState extends State<DashboardScreen>
         toolbarHeight: 36,
         leading: Consumer<BLEService>(
           builder: (context, bleService, _) {
-            final count = bleService.connectedDevices.where((d) => d.isConnected).length;
+            final count =
+                bleService.connectedDevices.where((d) => d.isConnected).length;
             return InkWell(
               onTap: () => _showDeviceDialog(context),
               borderRadius: BorderRadius.circular(8),
@@ -528,11 +533,13 @@ class _DashboardScreenState extends State<DashboardScreen>
             builder: (context, bleService, child) {
               if (!bleService.permissionsGranted) {
                 return Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                   color: Colors.orange.shade50,
                   child: Row(
                     children: [
-                      Icon(Icons.warning_amber, color: Colors.orange.shade700, size: 20),
+                      Icon(Icons.warning_amber,
+                          color: Colors.orange.shade700, size: 20),
                       const SizedBox(width: 8),
                       Expanded(
                         child: Text(
@@ -545,7 +552,8 @@ class _DashboardScreenState extends State<DashboardScreen>
                         ),
                       ),
                       TextButton(
-                        onPressed: () => _requestBlePermission(context, bleService),
+                        onPressed: () =>
+                            _requestBlePermission(context, bleService),
                         child: Text(
                           'Grant',
                           style: TextStyle(
@@ -568,7 +576,8 @@ class _DashboardScreenState extends State<DashboardScreen>
               color: Colors.red.shade50,
               child: Row(
                 children: [
-                  Icon(Icons.warning_amber, color: Colors.red.shade700, size: 20),
+                  Icon(Icons.warning_amber,
+                      color: Colors.red.shade700, size: 20),
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
@@ -598,7 +607,8 @@ class _DashboardScreenState extends State<DashboardScreen>
 
                 return LayoutBuilder(
                   builder: (context, constraints) {
-                    final isLandscape = constraints.maxWidth > constraints.maxHeight;
+                    final isLandscape =
+                        constraints.maxWidth > constraints.maxHeight;
                     final cols = isLandscape ? 5 : 4;
                     final rows = isLandscape ? 4 : 5;
                     final totalSlots = cols * rows;
@@ -618,7 +628,8 @@ class _DashboardScreenState extends State<DashboardScreen>
                           final device = connected[index];
                           final athlete = DatabaseService.instance
                               .getAthleteForSensor(device.id);
-                          return _buildSquareDeviceCard(device, index + 1, athlete);
+                          return _buildSquareDeviceCard(
+                              device, index + 1, athlete);
                         }
                         return _buildEmptySlot(index + 1);
                       },
@@ -632,9 +643,11 @@ class _DashboardScreenState extends State<DashboardScreen>
       ),
       floatingActionButton: Consumer<BLEService>(
         builder: (context, bleService, child) {
-          final connectedDevices = bleService.connectedDevices.where((d) => d.isConnected).toList();
-          debugPrint('FAB check: recording=$_isRecording, activeSessions=${_activeSessions.length}, connectedCount=${connectedDevices.length}');
-          
+          final connectedDevices =
+              bleService.connectedDevices.where((d) => d.isConnected).toList();
+          debugPrint(
+              'FAB check: recording=$_isRecording, activeSessions=${_activeSessions.length}, connectedCount=${connectedDevices.length}');
+
           VoidCallback? onPressed;
           if (!_isRecording && connectedDevices.isNotEmpty) {
             onPressed = () {
@@ -649,7 +662,7 @@ class _DashboardScreenState extends State<DashboardScreen>
           } else {
             debugPrint('FAB disabled: no connected devices');
           }
-          
+
           return Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -667,8 +680,9 @@ class _DashboardScreenState extends State<DashboardScreen>
                 heroTag: 'dashboard_fab',
                 onPressed: onPressed,
                 icon: Icon(_isRecording ? Icons.stop : Icons.play_arrow),
-                label: Text(
-                    _isRecording ? 'Stop Training (${_activeSessions.length})' : 'Start Training'),
+                label: Text(_isRecording
+                    ? 'Stop Training (${_activeSessions.length})'
+                    : 'Start Training'),
                 backgroundColor: _isRecording ? Colors.red : Colors.green,
               ),
             ],
@@ -697,7 +711,8 @@ class _DashboardScreenState extends State<DashboardScreen>
     );
   }
 
-  Widget _buildSquareDeviceCard(HRDevice device, int memberNumber, Person? athlete) {
+  Widget _buildSquareDeviceCard(
+      HRDevice device, int memberNumber, Person? athlete) {
     final zoneColor = _getHeartRateColorByTrainingZone(device.currentHeartRate);
 
     return Card(
@@ -768,7 +783,8 @@ class _DashboardScreenState extends State<DashboardScreen>
                 children: [
                   // Card content
                   Padding(
-                    padding: EdgeInsets.fromLTRB(w * 0.06, h * 0.07, w * 0.06, stripH + sparklineH + zoneBarsH),
+                    padding: EdgeInsets.fromLTRB(w * 0.06, h * 0.07, w * 0.06,
+                        stripH + sparklineH + zoneBarsH),
                     child: Row(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
@@ -835,7 +851,9 @@ class _DashboardScreenState extends State<DashboardScreen>
                         decoration: BoxDecoration(
                           color: hrvColor,
                           shape: BoxShape.circle,
-                          boxShadow: const [BoxShadow(color: Colors.black26, blurRadius: 2)],
+                          boxShadow: const [
+                            BoxShadow(color: Colors.black26, blurRadius: 2)
+                          ],
                         ),
                       ),
                     ),
@@ -843,7 +861,8 @@ class _DashboardScreenState extends State<DashboardScreen>
                   // Zone bars — sits between sparkline and bottom strip
                   if (zoneSecs != null)
                     Positioned(
-                      left: w * 0.04, right: w * 0.04,
+                      left: w * 0.04,
+                      right: w * 0.04,
                       bottom: stripH,
                       height: zoneBarsH,
                       child: _ZoneBars(zoneSecs: zoneSecs, height: zoneBarsH),
@@ -852,7 +871,8 @@ class _DashboardScreenState extends State<DashboardScreen>
                   // Sparkline — sits just above the zone bars (or strip if no session)
                   if (sparklineHistory.length >= 2)
                     Positioned(
-                      left: 0, right: 0,
+                      left: 0,
+                      right: 0,
                       bottom: stripH + (zoneSecs != null ? zoneBarsH : 0),
                       height: sparklineH,
                       child: ClipRect(
@@ -867,7 +887,9 @@ class _DashboardScreenState extends State<DashboardScreen>
 
                   // Bottom strip: zone name + signal + battery + assign button
                   Positioned(
-                    left: 0, right: 0, bottom: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
                     child: Container(
                       height: stripH,
                       decoration: const BoxDecoration(
@@ -892,7 +914,9 @@ class _DashboardScreenState extends State<DashboardScreen>
                           Row(
                             children: [
                               // RSSI signal bars
-                              _SignalIcon(bars: signalBars, size: (h * 0.11).clamp(8.0, 16.0)),
+                              _SignalIcon(
+                                  bars: signalBars,
+                                  size: (h * 0.11).clamp(8.0, 16.0)),
                               SizedBox(width: w * 0.02),
                               if (device.batteryLevel != null)
                                 Text(
@@ -903,9 +927,12 @@ class _DashboardScreenState extends State<DashboardScreen>
                                 ),
                               SizedBox(width: w * 0.02),
                               GestureDetector(
-                                onTap: () => _showSensorAssignmentDialog(context, device, athlete),
+                                onTap: () => _showSensorAssignmentDialog(
+                                    context, device, athlete),
                                 child: Icon(
-                                  athlete == null ? Icons.person_add : Icons.swap_horiz,
+                                  athlete == null
+                                      ? Icons.person_add
+                                      : Icons.swap_horiz,
                                   color: Colors.white70,
                                   size: (h * 0.12).clamp(10.0, 18.0),
                                 ),
@@ -925,7 +952,6 @@ class _DashboardScreenState extends State<DashboardScreen>
     );
   }
 
-
   /// Gets color based on training zones (more detailed than basic HR color)
   /// Zone 1 (Recovery): < 120 bpm - Light blue
   /// Zone 2 (Aerobic): 120-150 bpm - Green
@@ -935,11 +961,13 @@ class _DashboardScreenState extends State<DashboardScreen>
   // Standard 5-zone colors (Polar/Garmin convention)
   Color _getHeartRateColorByTrainingZone(int? heartRate) {
     if (heartRate == null) return const Color(0xFF757575); // grey — no data
-    if (heartRate < 120) return const Color(0xFF4FC3F7); // Z1 light blue — Recovery
+    if (heartRate < 120)
+      return const Color(0xFF4FC3F7); // Z1 light blue — Recovery
     if (heartRate < 150) return const Color(0xFF66BB6A); // Z2 green — Aerobic
     if (heartRate < 170) return const Color(0xFFFDD835); // Z3 yellow — Tempo
-    if (heartRate < 190) return const Color(0xFFFF7043); // Z4 orange — Threshold
-    return const Color(0xFFE53935);                       // Z5 red — Anaerobic
+    if (heartRate < 190)
+      return const Color(0xFFFF7043); // Z4 orange — Threshold
+    return const Color(0xFFE53935); // Z5 red — Anaerobic
   }
 
   int _getZoneIndex(int heartRate) {
@@ -960,7 +988,8 @@ class _DashboardScreenState extends State<DashboardScreen>
   }
 
   void _markLap() {
-    final lapNum = _sessionMarkers.where((m) => m.label.startsWith('Lap')).length + 1;
+    final lapNum =
+        _sessionMarkers.where((m) => m.label.startsWith('Lap')).length + 1;
     final marker = (time: DateTime.now(), label: 'Lap $lapNum');
     setState(() => _sessionMarkers.add(marker));
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
@@ -1024,7 +1053,8 @@ class _DashboardScreenState extends State<DashboardScreen>
     return 1;
   }
 
-  void _showSensorAssignmentDialog(BuildContext context, HRDevice device, Person? currentAthlete) {
+  void _showSensorAssignmentDialog(
+      BuildContext context, HRDevice device, Person? currentAthlete) {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -1041,7 +1071,8 @@ class _DashboardScreenState extends State<DashboardScreen>
             if (currentAthlete != null)
               Text(
                 'Currently assigned to: ${currentAthlete.name}',
-                style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
+                style:
+                    const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
               ),
             const SizedBox(height: 16),
             const Text(
@@ -1060,7 +1091,8 @@ class _DashboardScreenState extends State<DashboardScreen>
                 if (context.mounted) Navigator.pop(context);
                 setState(() {});
               },
-              child: const Text('Unassign', style: TextStyle(color: Colors.red)),
+              child:
+                  const Text('Unassign', style: TextStyle(color: Colors.red)),
             ),
           TextButton(
             onPressed: () => Navigator.pop(context),
@@ -1075,7 +1107,7 @@ class _DashboardScreenState extends State<DashboardScreen>
   /// Displays simulated heart rate data with training zone colors
   Widget _buildAthleteList(HRDevice device) {
     final athletes = DatabaseService.instance.getAthletes();
-    
+
     if (athletes.isEmpty) {
       return Padding(
         padding: const EdgeInsets.symmetric(vertical: 16),
@@ -1085,7 +1117,7 @@ class _DashboardScreenState extends State<DashboardScreen>
         ),
       );
     }
-    
+
     return Container(
       constraints: const BoxConstraints(maxHeight: 300),
       child: SingleChildScrollView(
@@ -1114,7 +1146,8 @@ class _DashboardScreenState extends State<DashboardScreen>
                 style: const TextStyle(fontSize: 11),
               ),
               trailing: isAssigned
-                  ? const Icon(Icons.check_circle, color: Colors.green, size: 20)
+                  ? const Icon(Icons.check_circle,
+                      color: Colors.green, size: 20)
                   : null,
               onTap: () async {
                 await DatabaseService.instance.assignSensorToAthlete(
@@ -1211,7 +1244,9 @@ class _SparklinePainter extends CustomPainter {
     final path = Path();
     for (int i = 0; i < points.length; i++) {
       final x = i / (points.length - 1) * size.width;
-      final y = size.height - ((points[i].value - minVal) / range) * size.height * 0.9 - size.height * 0.05;
+      final y = size.height -
+          ((points[i].value - minVal) / range) * size.height * 0.9 -
+          size.height * 0.05;
       if (i == 0) {
         path.moveTo(x, y);
       } else {
@@ -1270,11 +1305,11 @@ class _DeviceDialogState extends State<DeviceDialog> {
   @override
   void initState() {
     super.initState();
-    
+
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       // Don't reset BLE service - preserve connected devices
       final bleService = Provider.of<BLEService>(context, listen: false);
-      
+
       await _checkBluetoothAvailability();
       await bleService.checkPermissions(); // Check permissions on startup
       final error = await bleService.startScan();
@@ -1415,68 +1450,93 @@ class _DeviceDialogState extends State<DeviceDialog> {
                                 shrinkWrap: true,
                                 itemCount: bleService.discoveredDevices.length,
                                 itemBuilder: (context, index) {
-                                  final device = bleService.discoveredDevices[index];
-                            final isConnected = device.isConnected;
-                            final isConnecting =
-                                _connectingDevices.contains(device.id);
+                                  final device =
+                                      bleService.discoveredDevices[index];
+                                  final isConnected = device.isConnected;
+                                  final isConnecting =
+                                      _connectingDevices.contains(device.id);
 
-                            return ListTile(
-                              leading: const Icon(Icons.bluetooth),
-                              title: Text(device.name),
-                              subtitle:
-                                  Text('Signal: ${device.rssi} dBm'),
-                              trailing: isConnected
-                                  ? const Icon(Icons.check, color: Colors.green)
-                                  : bleService.connectedDevices.length >= 10
-                                      ? const Tooltip(
-                                          message: 'Max devices connected',
-                                          child: Icon(Icons.lock, color: Colors.grey),
-                                        )
-                                      : Row(
-                                          mainAxisSize: MainAxisSize.min,
-                                          children: [
-                                            ElevatedButton(
-                                              onPressed: isConnecting
-                                                  ? null
-                                                  : () async {
-                                                      setState(() {
-                                                        _connectingDevices.add(device.id);
-                                                      });
+                                  return ListTile(
+                                    leading: const Icon(Icons.bluetooth),
+                                    title: Text(device.name),
+                                    subtitle:
+                                        Text('Signal: ${device.rssi} dBm'),
+                                    trailing: isConnected
+                                        ? const Icon(Icons.check,
+                                            color: Colors.green)
+                                        : bleService.connectedDevices.length >=
+                                                10
+                                            ? const Tooltip(
+                                                message:
+                                                    'Max devices connected',
+                                                child: Icon(Icons.lock,
+                                                    color: Colors.grey),
+                                              )
+                                            : Row(
+                                                mainAxisSize: MainAxisSize.min,
+                                                children: [
+                                                  ElevatedButton(
+                                                    onPressed: isConnecting
+                                                        ? null
+                                                        : () async {
+                                                            setState(() {
+                                                              _connectingDevices
+                                                                  .add(device
+                                                                      .id);
+                                                            });
 
-                                                      try {
-                                                        final success = await bleService.connectDevice(device);
-                                                        if (mounted) {
-                                                          if (success) {
-                                                            ScaffoldMessenger.of(context).showSnackBar(
-                                                              SnackBar(content: Text('Connected to ${device.name}')),
-                                                            );
-                                                          } else {
-                                                            ScaffoldMessenger.of(context).showSnackBar(
-                                                              SnackBar(
-                                                                content: Text('Failed to connect to ${device.name}'),
-                                                                backgroundColor: Colors.red,
-                                                              ),
-                                                            );
-                                                          }
-                                                        }
-                                                      } finally {
-                                                        setState(() {
-                                                          _connectingDevices.remove(device.id);
-                                                        });
-                                                      }
-                                                    },
-                                              child: isConnecting
-                                                  ? const SizedBox(
-                                                      height: 16,
-                                                      width: 16,
-                                                      child: CircularProgressIndicator(strokeWidth: 2),
-                                                    )
-                                                  : const Text('Connect'),
-                                            ),
-                                            const SizedBox(width: 0),
-                                          ],
-                                        ),
-                            );
+                                                            try {
+                                                              final success =
+                                                                  await bleService
+                                                                      .connectDevice(
+                                                                          device);
+                                                              if (mounted) {
+                                                                if (success) {
+                                                                  ScaffoldMessenger.of(
+                                                                          context)
+                                                                      .showSnackBar(
+                                                                    SnackBar(
+                                                                        content:
+                                                                            Text('Connected to ${device.name}')),
+                                                                  );
+                                                                } else {
+                                                                  ScaffoldMessenger.of(
+                                                                          context)
+                                                                      .showSnackBar(
+                                                                    SnackBar(
+                                                                      content: Text(
+                                                                          'Failed to connect to ${device.name}'),
+                                                                      backgroundColor:
+                                                                          Colors
+                                                                              .red,
+                                                                    ),
+                                                                  );
+                                                                }
+                                                              }
+                                                            } finally {
+                                                              setState(() {
+                                                                _connectingDevices
+                                                                    .remove(
+                                                                        device
+                                                                            .id);
+                                                              });
+                                                            }
+                                                          },
+                                                    child: isConnecting
+                                                        ? const SizedBox(
+                                                            height: 16,
+                                                            width: 16,
+                                                            child:
+                                                                CircularProgressIndicator(
+                                                                    strokeWidth:
+                                                                        2),
+                                                          )
+                                                        : const Text('Connect'),
+                                                  ),
+                                                  const SizedBox(width: 0),
+                                                ],
+                                              ),
+                                  );
                                 },
                               ),
                       ),
@@ -1484,53 +1544,96 @@ class _DeviceDialogState extends State<DeviceDialog> {
                       const SizedBox(height: 8),
                       // Saved devices (previously connected) - useful when sensor doesn't advertise
                       FutureBuilder<List<HRDevice>>(
-                        future: Provider.of<BLEService>(context, listen: false).getSavedConnectedDevices(),
+                        future: Provider.of<BLEService>(context, listen: false)
+                            .getSavedConnectedDevices(),
                         builder: (context, snap) {
-                          if (!snap.hasData || snap.data!.isEmpty) return const SizedBox.shrink();
-                          
+                          if (!snap.hasData || snap.data!.isEmpty)
+                            return const SizedBox.shrink();
+
                           // Filter out devices that are already discovered or connected
                           final savedDevices = snap.data!
-                              .where((sd) => !bleService.discoveredDevices.any((d) => d.id == sd.id) &&
-                                            !bleService.connectedDevices.any((d) => d.id == sd.id))
+                              .where((sd) =>
+                                  !bleService.discoveredDevices
+                                      .any((d) => d.id == sd.id) &&
+                                  !bleService.connectedDevices
+                                      .any((d) => d.id == sd.id))
                               .toList();
-                          
-                          if (savedDevices.isEmpty) return const SizedBox.shrink();
-                          
+
+                          if (savedDevices.isEmpty)
+                            return const SizedBox.shrink();
+
                           return Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const Text('Saved Devices', style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold, color: Colors.grey)),
+                              const Text('Saved Devices',
+                                  style: TextStyle(
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.bold,
+                                      color: Colors.grey)),
                               const SizedBox(height: 6),
                               SizedBox(
-                                height: (savedDevices.length * 56).toDouble().clamp(0, 200),
+                                height: (savedDevices.length * 56)
+                                    .toDouble()
+                                    .clamp(0, 200),
                                 child: ListView.builder(
                                   itemCount: savedDevices.length,
                                   itemBuilder: (context, i) {
                                     final sd = savedDevices[i];
-                                    final isConnecting = _connectingDevices.contains(sd.id);
+                                    final isConnecting =
+                                        _connectingDevices.contains(sd.id);
                                     return ListTile(
-                                      leading: const Icon(Icons.history, color: Colors.grey),
-                                      title: Text(sd.name, style: const TextStyle(fontSize: 12)),
-                                      subtitle: Text(sd.id, style: const TextStyle(fontSize: 10)),
+                                      leading: const Icon(Icons.history,
+                                          color: Colors.grey),
+                                      title: Text(sd.name,
+                                          style: const TextStyle(fontSize: 12)),
+                                      subtitle: Text(sd.id,
+                                          style: const TextStyle(fontSize: 10)),
                                       trailing: ElevatedButton(
                                         onPressed: isConnecting
                                             ? null
                                             : () async {
-                                                setState(() { _connectingDevices.add(sd.id); });
+                                                setState(() {
+                                                  _connectingDevices.add(sd.id);
+                                                });
                                                 try {
-                                                  final success = await Provider.of<BLEService>(context, listen: false).connectDevice(sd);
+                                                  final success = await Provider
+                                                          .of<BLEService>(
+                                                              context,
+                                                              listen: false)
+                                                      .connectDevice(sd);
                                                   if (mounted) {
                                                     if (success) {
-                                                      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Restored ${sd.name}')));
+                                                      ScaffoldMessenger.of(
+                                                              context)
+                                                          .showSnackBar(SnackBar(
+                                                              content: Text(
+                                                                  'Restored ${sd.name}')));
                                                     } else {
-                                                      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Failed to restore ${sd.name}'), backgroundColor: Colors.red));
+                                                      ScaffoldMessenger.of(
+                                                              context)
+                                                          .showSnackBar(SnackBar(
+                                                              content: Text(
+                                                                  'Failed to restore ${sd.name}'),
+                                                              backgroundColor:
+                                                                  Colors.red));
                                                     }
                                                   }
                                                 } finally {
-                                                  setState(() { _connectingDevices.remove(sd.id); });
+                                                  setState(() {
+                                                    _connectingDevices
+                                                        .remove(sd.id);
+                                                  });
                                                 }
                                               },
-                                        child: isConnecting ? const SizedBox(height: 16, width: 16, child: CircularProgressIndicator(strokeWidth: 2)) : const Text('Restore', style: TextStyle(fontSize: 11)),
+                                        child: isConnecting
+                                            ? const SizedBox(
+                                                height: 16,
+                                                width: 16,
+                                                child:
+                                                    CircularProgressIndicator(
+                                                        strokeWidth: 2))
+                                            : const Text('Restore',
+                                                style: TextStyle(fontSize: 11)),
                                       ),
                                     );
                                   },

--- a/mobile_app/lib/screens/home_screen.dart
+++ b/mobile_app/lib/screens/home_screen.dart
@@ -8,6 +8,7 @@ import 'dashboard_screen.dart';
 import 'profile_screen.dart';
 import 'readiness_history_screen.dart';
 import 'settings_screen.dart';
+import '../utils/timezone_utils.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -107,10 +108,10 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
 
   Future<void> _syncAllUnsynced(BuildContext context) async {
     final dbService = Provider.of<DatabaseService>(context, listen: false);
-    
+
     // Check if there are any unsynced sessions
     final unsyncedSessions = dbService.getUnsyncedSessions();
-    
+
     if (unsyncedSessions.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -120,17 +121,17 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
       );
       return;
     }
-    
+
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text('Uploading ${unsyncedSessions.length} session(s)...'),
         duration: const Duration(seconds: 2),
       ),
     );
-    
+
     try {
       final supabaseRepo = SupabaseRepository();
-      
+
       // Check if user is authenticated
       if (supabaseRepo.currentUser == null) {
         if (context.mounted) {
@@ -144,17 +145,18 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
         }
         return;
       }
-      
+
       // Upload unsynced sessions to cloud
-      final uploadedCount = await dbService.syncAllUnsyncedSessions(supabaseRepo);
-      
+      final uploadedCount =
+          await dbService.syncAllUnsyncedSessions(supabaseRepo);
+
       if (context.mounted) {
         // Force UI refresh to update badge count
         setState(() {});
-        
+
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(uploadedCount > 0 
+            content: Text(uploadedCount > 0
                 ? 'Successfully uploaded $uploadedCount session(s)'
                 : 'No sessions to upload'),
             backgroundColor: uploadedCount > 0 ? Colors.green : Colors.blue,
@@ -176,7 +178,8 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
     }
   }
 
-  Future<void> _syncSingleSession(BuildContext context, TrainingSession session) async {
+  Future<void> _syncSingleSession(
+      BuildContext context, TrainingSession session) async {
     if (session.synced) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -186,21 +189,21 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
       );
       return;
     }
-    
+
     // Prevent double-sync
     if (_syncingSessions.contains(session.id)) {
       return;
     }
-    
+
     setState(() {
       _syncingSessions.add(session.id);
     });
-    
+
     final dbService = Provider.of<DatabaseService>(context, listen: false);
-    
+
     try {
       final supabaseRepo = SupabaseRepository();
-      
+
       // Check if user is authenticated
       if (supabaseRepo.currentUser == null) {
         if (context.mounted) {
@@ -214,14 +217,15 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
         }
         return;
       }
-      
+
       final success = await dbService.syncSessionToCloud(session, supabaseRepo);
-      
+
       if (context.mounted) {
         setState(() {}); // Force UI refresh
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(success ? 'Session synced successfully' : 'Sync failed'),
+            content:
+                Text(success ? 'Session synced successfully' : 'Sync failed'),
             backgroundColor: success ? Colors.green : Colors.red,
             duration: const Duration(seconds: 2),
           ),
@@ -247,7 +251,8 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
     }
   }
 
-  void _showDeleteConfirmation(BuildContext context, DatabaseService dbService, List<String> sessionIds, bool isMultiple) {
+  void _showDeleteConfirmation(BuildContext context, DatabaseService dbService,
+      List<String> sessionIds, bool isMultiple) {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -268,12 +273,12 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
                 dbService.deleteSession(sessionId);
               }
               Navigator.pop(context);
-              
+
               setState(() {
                 _isMultiSelectMode = false;
                 _selectedSessions.clear();
               });
-              
+
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
                   content: Text(
@@ -371,7 +376,8 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
                     context: context,
                     builder: (context) => AlertDialog(
                       title: const Text('Delete Session'),
-                      content: const Text('Are you sure you want to delete this session?'),
+                      content: const Text(
+                          'Are you sure you want to delete this session?'),
                       actions: [
                         TextButton(
                           onPressed: () => Navigator.pop(context, false),
@@ -379,7 +385,8 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
                         ),
                         TextButton(
                           onPressed: () => Navigator.pop(context, true),
-                          child: const Text('Delete', style: TextStyle(color: Colors.red)),
+                          child: const Text('Delete',
+                              style: TextStyle(color: Colors.red)),
                         ),
                       ],
                     ),
@@ -396,7 +403,8 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
                   );
                 },
                 child: Card(
-                  margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  margin:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                   color: isSelected ? Colors.blue.shade50 : null,
                   child: ListTile(
                     dense: true,
@@ -425,7 +433,8 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
                         // Show athlete name if available
                         Consumer<DatabaseService>(
                           builder: (context, dbService, child) {
-                            final person = dbService.getPersonById(session.personId);
+                            final person =
+                                dbService.getPersonById(session.personId);
                             if (person != null) {
                               return Text(
                                 person.name,
@@ -444,7 +453,7 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
                       ],
                     ),
                     subtitle: Text(
-                      '${_formatDuration(session.duration)} • ${session.startTime.toString().substring(0, 16)}',
+                      '${_formatDuration(session.duration)} • ${TimezoneUtils.formatDateTime(session.startTime)}',
                       style: const TextStyle(fontSize: 11),
                     ),
                     trailing: _isMultiSelectMode
@@ -453,16 +462,25 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
                             ? const SizedBox(
                                 width: 20,
                                 height: 20,
-                                child: CircularProgressIndicator(strokeWidth: 2),
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2),
                               )
                             : IconButton(
                                 icon: Icon(
-                                  session.synced ? Icons.cloud_done : Icons.cloud_upload,
-                                  color: session.synced ? Colors.green : Colors.orange,
+                                  session.synced
+                                      ? Icons.cloud_done
+                                      : Icons.cloud_upload,
+                                  color: session.synced
+                                      ? Colors.green
+                                      : Colors.orange,
                                   size: 20,
                                 ),
-                                onPressed: session.synced ? null : () => _syncSingleSession(context, session),
-                                tooltip: session.synced ? 'Synced' : 'Tap to upload',
+                                onPressed: session.synced
+                                    ? null
+                                    : () =>
+                                        _syncSingleSession(context, session),
+                                tooltip:
+                                    session.synced ? 'Synced' : 'Tap to upload',
                               ),
                     onTap: () {
                       if (_isMultiSelectMode) {
@@ -472,7 +490,8 @@ class _TrainingHistoryWidgetState extends State<TrainingHistoryWidget> {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => SessionVisualizationScreen(session: session),
+                            builder: (context) =>
+                                SessionVisualizationScreen(session: session),
                           ),
                         );
                       }

--- a/mobile_app/lib/screens/home_screen.dart
+++ b/mobile_app/lib/screens/home_screen.dart
@@ -6,6 +6,7 @@ import '../models/training_session.dart';
 import '../screens/session_visualization_screen.dart';
 import 'dashboard_screen.dart';
 import 'profile_screen.dart';
+import 'readiness_history_screen.dart';
 import 'settings_screen.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -22,6 +23,7 @@ class _HomeScreenState extends State<HomeScreen> {
   late final List<Widget> _screens = [
     const DashboardScreen(),
     const TrainingHistoryWidget(),
+    const ReadinessHistoryScreen(),
     const ProfileScreen(),
     const SettingsScreen(),
   ];
@@ -52,6 +54,11 @@ class _HomeScreenState extends State<HomeScreen> {
           NavigationDestination(
             icon: Icon(Icons.history),
             label: 'History',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.monitor_heart_outlined),
+            selectedIcon: Icon(Icons.monitor_heart),
+            label: 'Readiness',
           ),
           NavigationDestination(
             icon: Icon(Icons.person),

--- a/mobile_app/lib/screens/profile_screen.dart
+++ b/mobile_app/lib/screens/profile_screen.dart
@@ -760,10 +760,13 @@ class SyncDialog extends StatelessWidget {
                             );
                           }
                         } catch (e) {
+                          debugPrint('[SyncDialog] Sync failed: $e');
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content: Text('Sync failed: $e'),
+                              const SnackBar(
+                                content: Text(
+                                  'Sync failed. Please check your connection and try again.',
+                                ),
                                 backgroundColor: Colors.red,
                               ),
                             );

--- a/mobile_app/lib/screens/profile_screen.dart
+++ b/mobile_app/lib/screens/profile_screen.dart
@@ -752,11 +752,22 @@ class SyncDialog extends StatelessWidget {
                     ),
                     ElevatedButton(
                       onPressed: () async {
-                        await syncService.syncAll();
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(content: Text('Sync completed')),
-                          );
+                        try {
+                          await syncService.syncAll();
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('Sync completed')),
+                            );
+                          }
+                        } catch (e) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text('Sync failed: $e'),
+                                backgroundColor: Colors.red,
+                              ),
+                            );
+                          }
                         }
                       },
                       child: syncService.isSyncing

--- a/mobile_app/lib/screens/readiness_history_screen.dart
+++ b/mobile_app/lib/screens/readiness_history_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import '../models/person.dart';
 import '../models/readiness_measurement.dart';
 import '../services/database_service.dart';
 import '../services/hrv_service.dart';
+import '../utils/timezone_utils.dart';
 
 class ReadinessHistoryScreen extends StatefulWidget {
   final Person? initialAthlete;
@@ -154,7 +154,7 @@ class _ReadinessMeasurementCard extends StatelessWidget {
         ),
         title: Text(person?.name ?? 'Unknown athlete'),
         subtitle: Text(
-          '${DateFormat('yyyy-MM-dd HH:mm').format(measurement.measuredAt)} • '
+          '${TimezoneUtils.formatDateTime(measurement.measuredAt)} • '
           'RMSSD ${measurement.rmssd.toStringAsFixed(1)} ms • '
           'RHR ${measurement.restingHR?.toString() ?? '--'} bpm',
         ),
@@ -265,8 +265,7 @@ class ReadinessMeasurementDetailScreen extends StatelessWidget {
                     style: Theme.of(context).textTheme.titleLarge,
                   ),
                   const SizedBox(height: 8),
-                  Text(DateFormat('yyyy-MM-dd HH:mm')
-                      .format(measurement.measuredAt)),
+                  Text(TimezoneUtils.formatDateTime(measurement.measuredAt)),
                   const SizedBox(height: 8),
                   Text('Device: ${measurement.deviceId}'),
                   Text('Duration: ${measurement.durationSec}s'),

--- a/mobile_app/lib/screens/readiness_screen.dart
+++ b/mobile_app/lib/screens/readiness_screen.dart
@@ -434,138 +434,162 @@ class _ReadinessScreenState extends State<ReadinessScreen> {
         ? (r.rmssd / baseline * 100).clamp(0.0, 150.0)
         : null;
 
-    return ListView(
-      padding: const EdgeInsets.all(20),
+    return Column(
       children: [
-        // Header card
-        Card(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              children: [
-                Text(_selectedAthlete!.name,
-                    style: Theme.of(context).textTheme.titleMedium),
-                const SizedBox(height: 4),
-                Text(
-                  '$_durationMinutes min measurement · ${r.validIntervals} RR intervals',
-                  style: TextStyle(fontSize: 12, color: Colors.grey[600]),
-                ),
-                if (readinessPct != null) ...[
-                  const SizedBox(height: 12),
-                  _ReadinessBadge(readinessPct),
-                ],
-              ],
-            ),
-          ),
-        ),
-        const SizedBox(height: 12),
-
-        // HRV metrics grid
-        GridView.count(
-          crossAxisCount: 2,
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          crossAxisSpacing: 10,
-          mainAxisSpacing: 10,
-          childAspectRatio: 2.2,
-          children: [
-            _MetricCard(
-                label: 'RMSSD',
-                value: '${r.rmssd.toStringAsFixed(1)} ms',
-                subtitle: 'Parasympathetic activity'),
-            _MetricCard(
-                label: 'SDNN',
-                value: '${r.sdnn.toStringAsFixed(1)} ms',
-                subtitle: 'Overall HRV'),
-            _MetricCard(
-                label: 'pNN50',
-                value: '${r.pnn50.toStringAsFixed(1)}%',
-                subtitle: 'Vagal tone'),
-            _MetricCard(
-                label: 'Mean RR',
-                value: '${r.meanRR.toStringAsFixed(0)} ms',
-                subtitle:
-                    '≈ ${(60000 / r.meanRR).toStringAsFixed(0)} bpm rest'),
-            _MetricCard(
-                label: 'SD1',
-                value: '${r.sd1.toStringAsFixed(1)} ms',
-                subtitle: 'Short-term variability'),
-            _MetricCard(
-                label: 'Quality',
-                value: '${qualityPct.toStringAsFixed(0)}%',
-                subtitle: '${r.validIntervals} valid intervals'),
-          ],
-        ),
-        const SizedBox(height: 20),
-
-        // Feeling score
-        Text('How do you feel today?',
-            style: Theme.of(context).textTheme.labelLarge),
-        const SizedBox(height: 8),
-        Text(
-          _selectedAthlete!.name,
-          style: TextStyle(fontSize: 13, color: Colors.grey[600]),
-        ),
-        const SizedBox(height: 10),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: List.generate(5, (i) {
-            final score = i + 1;
-            final labels = ['Very Bad', 'Bad', 'OK', 'Good', 'Very Good'];
-            final emojis = ['😞', '😕', '😐', '🙂', '😄'];
-            final selected = _feelingScore == score;
-            return GestureDetector(
-              onTap: () => setState(() => _feelingScore = score),
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 150),
-                padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 6),
-                decoration: BoxDecoration(
-                  color: selected
-                      ? Theme.of(context).colorScheme.primaryContainer
-                      : Colors.transparent,
-                  borderRadius: BorderRadius.circular(10),
-                  border: selected
-                      ? Border.all(
-                          color: Theme.of(context).colorScheme.primary,
-                          width: 2)
-                      : Border.all(color: Colors.transparent),
-                ),
-                child: Column(
-                  children: [
-                    Text(emojis[i], style: const TextStyle(fontSize: 26)),
-                    const SizedBox(height: 2),
-                    Text(labels[i],
-                        style: TextStyle(
-                            fontSize: 10,
-                            color: selected
-                                ? Theme.of(context).colorScheme.primary
-                                : Colors.grey[600],
-                            fontWeight: selected
-                                ? FontWeight.bold
-                                : FontWeight.normal)),
-                  ],
+        // Scrollable metrics area
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(20, 20, 20, 8),
+            children: [
+              // Header card
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    children: [
+                      Text(_selectedAthlete!.name,
+                          style: Theme.of(context).textTheme.titleMedium),
+                      const SizedBox(height: 4),
+                      Text(
+                        '$_durationMinutes min measurement · ${r.validIntervals} RR intervals',
+                        style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                      ),
+                      if (readinessPct != null) ...[
+                        const SizedBox(height: 12),
+                        _ReadinessBadge(readinessPct),
+                      ],
+                    ],
+                  ),
                 ),
               ),
-            );
-          }),
-        ),
-        const SizedBox(height: 28),
+              const SizedBox(height: 12),
 
-        // Save button
-        FilledButton.icon(
-          onPressed: _saveResult,
-          icon: const Icon(Icons.save),
-          label: const Text('Save Result'),
-          style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
+              // HRV metrics grid
+              GridView.count(
+                crossAxisCount: 2,
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                crossAxisSpacing: 10,
+                mainAxisSpacing: 10,
+                childAspectRatio: 2.2,
+                children: [
+                  _MetricCard(
+                      label: 'RMSSD',
+                      value: '${r.rmssd.toStringAsFixed(1)} ms',
+                      subtitle: 'Parasympathetic activity'),
+                  _MetricCard(
+                      label: 'SDNN',
+                      value: '${r.sdnn.toStringAsFixed(1)} ms',
+                      subtitle: 'Overall HRV'),
+                  _MetricCard(
+                      label: 'pNN50',
+                      value: '${r.pnn50.toStringAsFixed(1)}%',
+                      subtitle: 'Vagal tone'),
+                  _MetricCard(
+                      label: 'Mean RR',
+                      value: '${r.meanRR.toStringAsFixed(0)} ms',
+                      subtitle:
+                          '≈ ${(60000 / r.meanRR).toStringAsFixed(0)} bpm rest'),
+                  _MetricCard(
+                      label: 'SD1',
+                      value: '${r.sd1.toStringAsFixed(1)} ms',
+                      subtitle: 'Short-term variability'),
+                  _MetricCard(
+                      label: 'Quality',
+                      value: '${qualityPct.toStringAsFixed(0)}%',
+                      subtitle: '${r.validIntervals} valid intervals'),
+                ],
+              ),
+              const SizedBox(height: 20),
+
+              // Feeling score
+              Text('How do you feel today?',
+                  style: Theme.of(context).textTheme.labelLarge),
+              const SizedBox(height: 8),
+              Text(
+                _selectedAthlete!.name,
+                style: TextStyle(fontSize: 13, color: Colors.grey[600]),
+              ),
+              const SizedBox(height: 10),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: List.generate(5, (i) {
+                  final score = i + 1;
+                  final labels = ['Very Bad', 'Bad', 'OK', 'Good', 'Very Good'];
+                  final emojis = ['😞', '😕', '😐', '🙂', '😄'];
+                  final selected = _feelingScore == score;
+                  return GestureDetector(
+                    onTap: () => setState(() => _feelingScore = score),
+                    child: AnimatedContainer(
+                      duration: const Duration(milliseconds: 150),
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 8, horizontal: 6),
+                      decoration: BoxDecoration(
+                        color: selected
+                            ? Theme.of(context).colorScheme.primaryContainer
+                            : Colors.transparent,
+                        borderRadius: BorderRadius.circular(10),
+                        border: selected
+                            ? Border.all(
+                                color: Theme.of(context).colorScheme.primary,
+                                width: 2)
+                            : Border.all(color: Colors.transparent),
+                      ),
+                      child: Column(
+                        children: [
+                          Text(emojis[i],
+                              style: const TextStyle(fontSize: 26)),
+                          const SizedBox(height: 2),
+                          Text(labels[i],
+                              style: TextStyle(
+                                  fontSize: 10,
+                                  color: selected
+                                      ? Theme.of(context).colorScheme.primary
+                                      : Colors.grey[600],
+                                  fontWeight: selected
+                                      ? FontWeight.bold
+                                      : FontWeight.normal)),
+                        ],
+                      ),
+                    ),
+                  );
+                }),
+              ),
+            ],
+          ),
         ),
-        const SizedBox(height: 8),
-        TextButton(
-          onPressed: () => setState(() {
-            _phase = _Phase.setup;
-            _result = null;
-            _feelingScore = null;
-          }),
-          child: const Text('Measure Again'),
+
+        // Sticky bottom action bar — always visible, never scrolled away
+        Container(
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+          decoration: BoxDecoration(
+            color: Theme.of(context).scaffoldBackgroundColor,
+            border: Border(
+              top: BorderSide(color: Colors.grey.shade200),
+            ),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              FilledButton.icon(
+                onPressed: _saveResult,
+                icon: const Icon(Icons.save),
+                label: const Text('Save Result'),
+                style: FilledButton.styleFrom(
+                    minimumSize: const Size.fromHeight(48)),
+              ),
+              const SizedBox(height: 6),
+              TextButton(
+                onPressed: () => setState(() {
+                  _phase = _Phase.setup;
+                  _result = null;
+                  _feelingScore = null;
+                }),
+                child:
+                    const Text('Measure Again'),
+              ),
+            ],
+          ),
         ),
       ],
     );

--- a/mobile_app/lib/screens/session_visualization_screen.dart
+++ b/mobile_app/lib/screens/session_visualization_screen.dart
@@ -4,6 +4,7 @@ import 'package:fl_chart/fl_chart.dart';
 import '../models/training_session.dart';
 import '../utils/hr_data_processing.dart';
 import '../utils/hrv_analysis.dart';
+import '../utils/timezone_utils.dart';
 
 class SessionVisualizationScreen extends StatefulWidget {
   final TrainingSession session;
@@ -14,8 +15,7 @@ class SessionVisualizationScreen extends StatefulWidget {
       _SessionVisualizationScreenState();
 }
 
-class _SessionVisualizationScreenState
-    extends State<SessionVisualizationScreen>
+class _SessionVisualizationScreenState extends State<SessionVisualizationScreen>
     with SingleTickerProviderStateMixin {
   bool _trimEnabled = false;
   bool _noiseFilter = false;
@@ -60,7 +60,8 @@ class _SessionVisualizationScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(session.title.isNotEmpty ? session.title : session.trainingType,
+        title: Text(
+            session.title.isNotEmpty ? session.title : session.trainingType,
             style: const TextStyle(fontSize: 16)),
         toolbarHeight: 36,
         actions: [
@@ -102,7 +103,10 @@ class _SessionVisualizationScreenState
   Widget _buildCompactInfoCard() {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-      color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+      color: Theme.of(context)
+          .colorScheme
+          .surfaceContainerHighest
+          .withValues(alpha: 0.4),
       child: Row(
         children: [
           // Left: general info
@@ -119,7 +123,8 @@ class _SessionVisualizationScreenState
             ),
           ),
           // Divider
-          Container(width: 1, height: 56, color: Colors.grey.withValues(alpha: 0.3)),
+          Container(
+              width: 1, height: 56, color: Colors.grey.withValues(alpha: 0.3)),
           const SizedBox(width: 16),
           // Right: HR stats
           Expanded(
@@ -131,12 +136,14 @@ class _SessionVisualizationScreenState
                       color: Colors.orange),
                 if (session.maxHeartRate != null) ...[
                   const SizedBox(height: 4),
-                  _infoItem(Icons.trending_up, 'Max  ${session.maxHeartRate} bpm',
+                  _infoItem(
+                      Icons.trending_up, 'Max  ${session.maxHeartRate} bpm',
                       color: Colors.red),
                 ],
                 if (session.minHeartRate != null) ...[
                   const SizedBox(height: 4),
-                  _infoItem(Icons.trending_down, 'Min  ${session.minHeartRate} bpm',
+                  _infoItem(
+                      Icons.trending_down, 'Min  ${session.minHeartRate} bpm',
                       color: Colors.blue),
                 ],
               ],
@@ -183,7 +190,8 @@ class _SessionVisualizationScreenState
                     title: const Text('Trim warmup / cooldown',
                         style: TextStyle(fontSize: 13)),
                     subtitle: _trimEnabled
-                        ? Text('Warmup ${_warmupSec}s · Cooldown ${_cooldownSec}s',
+                        ? Text(
+                            'Warmup ${_warmupSec}s · Cooldown ${_cooldownSec}s',
                             style: const TextStyle(fontSize: 11))
                         : null,
                     value: _trimEnabled,
@@ -193,11 +201,16 @@ class _SessionVisualizationScreenState
                   ),
                   if (_trimEnabled)
                     Row(children: [
-                      Expanded(child: _slider('Warmup', _warmupSec, (v) => _warmupSec = v)),
-                      Expanded(child: _slider('Cooldown', _cooldownSec, (v) => _cooldownSec = v)),
+                      Expanded(
+                          child: _slider(
+                              'Warmup', _warmupSec, (v) => _warmupSec = v)),
+                      Expanded(
+                          child: _slider('Cooldown', _cooldownSec,
+                              (v) => _cooldownSec = v)),
                     ]),
                   SwitchListTile(
-                    title: const Text('Noise filter', style: TextStyle(fontSize: 13)),
+                    title: const Text('Noise filter',
+                        style: TextStyle(fontSize: 13)),
                     value: _noiseFilter,
                     onChanged: (v) => setState(() => _noiseFilter = v),
                     contentPadding: EdgeInsets.zero,
@@ -246,7 +259,8 @@ class _SessionVisualizationScreenState
         child: Padding(
           padding: const EdgeInsets.all(32),
           child: Column(mainAxisSize: MainAxisSize.min, children: [
-            Icon(Icons.monitor_heart_outlined, size: 48, color: Colors.grey[400]),
+            Icon(Icons.monitor_heart_outlined,
+                size: 48, color: Colors.grey[400]),
             const SizedBox(height: 12),
             Text('Not enough data for HRV analysis\n(need ≥10 HR samples)',
                 textAlign: TextAlign.center,
@@ -257,7 +271,8 @@ class _SessionVisualizationScreenState
     }
 
     final hrv = HrvAnalysis.analyze(rr);
-    final rolling = HrvAnalysis.rollingRmssd(rr, windowSize: min(30, rr.length ~/ 3));
+    final rolling =
+        HrvAnalysis.rollingRmssd(rr, windowSize: min(30, rr.length ~/ 3));
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(12),
@@ -292,23 +307,18 @@ class _SessionVisualizationScreenState
           const SizedBox(height: 10),
           Row(children: [
             _hrvMetricTile('RMSSD', hrv.rmssd, 'ms',
-                low: 20, mid: 40, high: 60,
-                note: 'Parasympathetic tone'),
+                low: 20, mid: 40, high: 60, note: 'Parasympathetic tone'),
             _hrvMetricTile('SDNN', hrv.sdnn, 'ms',
-                low: 20, mid: 50, high: 100,
-                note: 'Overall variability'),
+                low: 20, mid: 50, high: 100, note: 'Overall variability'),
             _hrvMetricTile('pNN50', hrv.pnn50, '%',
-                low: 5, mid: 15, high: 30,
-                note: 'Vagal activity'),
+                low: 5, mid: 15, high: 30, note: 'Vagal activity'),
           ]),
           const SizedBox(height: 8),
           Row(children: [
             _hrvMetricTile('SD1', hrv.sd1, 'ms',
-                low: 10, mid: 25, high: 45,
-                note: 'Short-term (beat-to-beat)'),
+                low: 10, mid: 25, high: 45, note: 'Short-term (beat-to-beat)'),
             _hrvMetricTile('SD2', hrv.sd2, 'ms',
-                low: 20, mid: 50, high: 90,
-                note: 'Long-term variability'),
+                low: 20, mid: 50, high: 90, note: 'Long-term variability'),
             Expanded(
               child: Column(children: [
                 Text(hrv.stressLevel,
@@ -317,7 +327,8 @@ class _SessionVisualizationScreenState
                         fontWeight: FontWeight.bold,
                         color: _stressColor(hrv.stressLevel))),
                 const SizedBox(height: 2),
-                Text('Stress', style: TextStyle(fontSize: 11, color: Colors.grey[600])),
+                Text('Stress',
+                    style: TextStyle(fontSize: 11, color: Colors.grey[600])),
                 const SizedBox(height: 2),
                 Text('${hrv.validIntervals}/${hrv.totalIntervals} valid',
                     style: TextStyle(fontSize: 10, color: Colors.grey[500])),
@@ -330,7 +341,10 @@ class _SessionVisualizationScreenState
   }
 
   Widget _hrvMetricTile(String label, double value, String unit,
-      {required double low, required double mid, required double high, required String note}) {
+      {required double low,
+      required double mid,
+      required double high,
+      required String note}) {
     final color = value >= high
         ? Colors.green
         : value >= mid
@@ -374,7 +388,8 @@ class _SessionVisualizationScreenState
             const Text('Poincaré Plot',
                 style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14)),
             const SizedBox(width: 8),
-            Text('SD1 ${hrv.sd1.toStringAsFixed(1)} ms · SD2 ${hrv.sd2.toStringAsFixed(1)} ms',
+            Text(
+                'SD1 ${hrv.sd1.toStringAsFixed(1)} ms · SD2 ${hrv.sd2.toStringAsFixed(1)} ms',
                 style: TextStyle(fontSize: 11, color: Colors.grey[600])),
           ]),
           const SizedBox(height: 4),
@@ -390,12 +405,9 @@ class _SessionVisualizationScreenState
               minY: minRR,
               maxY: maxRR,
               borderData: FlBorderData(
-                  show: true,
-                  border: Border.all(color: Colors.grey.shade300)),
+                  show: true, border: Border.all(color: Colors.grey.shade300)),
               gridData: const FlGridData(
-                  show: true,
-                  horizontalInterval: 100,
-                  verticalInterval: 100),
+                  show: true, horizontalInterval: 100, verticalInterval: 100),
               titlesData: FlTitlesData(
                 leftTitles: AxisTitles(
                     axisNameWidget: const Text('RR[i+1] ms',
@@ -407,18 +419,18 @@ class _SessionVisualizationScreenState
                         getTitlesWidget: (v, _) => Text(v.toInt().toString(),
                             style: const TextStyle(fontSize: 9)))),
                 bottomTitles: AxisTitles(
-                    axisNameWidget: const Text('RR[i] ms',
-                        style: TextStyle(fontSize: 10)),
+                    axisNameWidget:
+                        const Text('RR[i] ms', style: TextStyle(fontSize: 10)),
                     sideTitles: SideTitles(
                         showTitles: true,
                         reservedSize: 28,
                         interval: 100,
                         getTitlesWidget: (v, _) => Text(v.toInt().toString(),
                             style: const TextStyle(fontSize: 9)))),
-                rightTitles: const AxisTitles(
-                    sideTitles: SideTitles(showTitles: false)),
-                topTitles: const AxisTitles(
-                    sideTitles: SideTitles(showTitles: false)),
+                rightTitles:
+                    const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                topTitles:
+                    const AxisTitles(sideTitles: SideTitles(showTitles: false)),
               ),
               scatterTouchData: ScatterTouchData(enabled: false),
             )),
@@ -430,9 +442,8 @@ class _SessionVisualizationScreenState
 
   /// Rolling RMSSD trend line
   Widget _buildRollingRmssdCard(List<({int index, double rmssd})> rolling) {
-    final spots = rolling
-        .map((p) => FlSpot(p.index.toDouble(), p.rmssd))
-        .toList();
+    final spots =
+        rolling.map((p) => FlSpot(p.index.toDouble(), p.rmssd)).toList();
     final maxY = spots.map((s) => s.y).reduce(max) + 10;
 
     return Card(
@@ -452,8 +463,7 @@ class _SessionVisualizationScreenState
               gridData: const FlGridData(
                   show: true, horizontalInterval: 20, verticalInterval: 20),
               borderData: FlBorderData(
-                  show: true,
-                  border: Border.all(color: Colors.grey.shade300)),
+                  show: true, border: Border.all(color: Colors.grey.shade300)),
               titlesData: FlTitlesData(
                 leftTitles: AxisTitles(
                     sideTitles: SideTitles(
@@ -462,12 +472,12 @@ class _SessionVisualizationScreenState
                         interval: 20,
                         getTitlesWidget: (v, _) => Text(v.toInt().toString(),
                             style: const TextStyle(fontSize: 9)))),
-                bottomTitles: const AxisTitles(
-                    sideTitles: SideTitles(showTitles: false)),
-                rightTitles: const AxisTitles(
-                    sideTitles: SideTitles(showTitles: false)),
-                topTitles: const AxisTitles(
-                    sideTitles: SideTitles(showTitles: false)),
+                bottomTitles:
+                    const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                rightTitles:
+                    const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                topTitles:
+                    const AxisTitles(sideTitles: SideTitles(showTitles: false)),
               ),
               lineBarsData: [
                 LineChartBarData(
@@ -477,15 +487,11 @@ class _SessionVisualizationScreenState
                   barWidth: 2,
                   dotData: const FlDotData(show: false),
                   belowBarData: BarAreaData(
-                      show: true,
-                      color: Colors.teal.withValues(alpha: 0.15)),
+                      show: true, color: Colors.teal.withValues(alpha: 0.15)),
                 ),
                 // Reference line at 20ms (high stress threshold)
                 LineChartBarData(
-                  spots: [
-                    FlSpot(spots.first.x, 20),
-                    FlSpot(spots.last.x, 20)
-                  ],
+                  spots: [FlSpot(spots.first.x, 20), FlSpot(spots.last.x, 20)],
                   color: Colors.red.withValues(alpha: 0.4),
                   barWidth: 1,
                   dashArray: [4, 4],
@@ -529,7 +535,8 @@ class _SessionVisualizationScreenState
               style: TextStyle(
                   fontSize: 11,
                   fontWeight: FontWeight.w600,
-                  color: ratio < 0.25 ? Colors.orange[800] : Colors.green[800])),
+                  color:
+                      ratio < 0.25 ? Colors.orange[800] : Colors.green[800])),
         ]),
       ),
     );
@@ -543,8 +550,7 @@ class _SessionVisualizationScreenState
       ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
     final start = sorted.first.timestamp;
     final spots = sorted
-        .map((d) => FlSpot(
-            d.timestamp.difference(start).inSeconds.toDouble(),
+        .map((d) => FlSpot(d.timestamp.difference(start).inSeconds.toDouble(),
             d.heartRate.toDouble()))
         .toList();
     final minY = spots.map((s) => s.y).reduce(min) - 10;
@@ -555,16 +561,16 @@ class _SessionVisualizationScreenState
       maxY: maxY,
       gridData: const FlGridData(
           show: true, horizontalInterval: 20, verticalInterval: 60),
-      borderData:
-          FlBorderData(show: true, border: Border.all(color: Colors.grey.shade300)),
+      borderData: FlBorderData(
+          show: true, border: Border.all(color: Colors.grey.shade300)),
       titlesData: FlTitlesData(
         leftTitles: AxisTitles(
             sideTitles: SideTitles(
                 showTitles: true,
                 reservedSize: 36,
                 interval: 20,
-                getTitlesWidget: (v, _) =>
-                    Text(v.toInt().toString(), style: const TextStyle(fontSize: 9)))),
+                getTitlesWidget: (v, _) => Text(v.toInt().toString(),
+                    style: const TextStyle(fontSize: 9)))),
         bottomTitles: AxisTitles(
             sideTitles: SideTitles(
                 showTitles: true,
@@ -574,8 +580,7 @@ class _SessionVisualizationScreenState
                     style: const TextStyle(fontSize: 9)))),
         rightTitles:
             const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-        topTitles:
-            const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
       ),
       lineBarsData: [
         LineChartBarData(
@@ -584,8 +589,8 @@ class _SessionVisualizationScreenState
           color: Colors.red,
           barWidth: 2,
           dotData: const FlDotData(show: false),
-          belowBarData: BarAreaData(
-              show: true, color: Colors.red.withValues(alpha: 0.1)),
+          belowBarData:
+              BarAreaData(show: true, color: Colors.red.withValues(alpha: 0.1)),
         ),
       ],
       lineTouchData: LineTouchData(
@@ -593,8 +598,7 @@ class _SessionVisualizationScreenState
           getTooltipItems: (spots) => spots.map((s) {
             final m = (s.x / 60).floor();
             final sec = (s.x % 60).round();
-            return LineTooltipItem(
-                '${m}m ${sec}s\n${s.y.toInt()} bpm',
+            return LineTooltipItem('${m}m ${sec}s\n${s.y.toInt()} bpm',
                 const TextStyle(color: Colors.white, fontSize: 11));
           }).toList(),
         ),
@@ -606,16 +610,18 @@ class _SessionVisualizationScreenState
 
   Color _stressColor(String level) {
     switch (level) {
-      case 'Low': return Colors.green;
-      case 'Moderate': return Colors.orange;
-      case 'High': return Colors.deepOrange;
-      default: return Colors.red;
+      case 'Low':
+        return Colors.green;
+      case 'Moderate':
+        return Colors.orange;
+      case 'High':
+        return Colors.deepOrange;
+      default:
+        return Colors.red;
     }
   }
 
-  String _formatDate(DateTime dt) =>
-      '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')} '
-      '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
+  String _formatDate(DateTime dt) => TimezoneUtils.formatDateTime(dt);
 
   String _formatDuration(int s) {
     final h = s ~/ 3600;

--- a/mobile_app/lib/screens/training_history_screen.dart
+++ b/mobile_app/lib/screens/training_history_screen.dart
@@ -4,6 +4,7 @@ import '../models/person.dart';
 import '../models/training_session.dart';
 import '../services/database_service.dart';
 import '../services/settings_service.dart';
+import '../utils/timezone_utils.dart';
 
 class TrainingHistoryScreen extends StatefulWidget {
   const TrainingHistoryScreen({super.key});
@@ -22,8 +23,10 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
   ) {
     return sessions.where((s) {
       final person = personMap[s.personId];
-      if (_selectedCategory != null && person?.category != _selectedCategory) return false;
-      if (_selectedGroup != null && person?.group != _selectedGroup) return false;
+      if (_selectedCategory != null && person?.category != _selectedCategory)
+        return false;
+      if (_selectedGroup != null && person?.group != _selectedGroup)
+        return false;
       return true;
     }).toList();
   }
@@ -55,8 +58,8 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
                       label: 'Category',
                       options: categories,
                       selected: _selectedCategory,
-                      onSelected: (v) => setState(() =>
-                          _selectedCategory = _selectedCategory == v ? null : v),
+                      onSelected: (v) => setState(() => _selectedCategory =
+                          _selectedCategory == v ? null : v),
                     ),
                   ],
                   if (groups.isNotEmpty) ...[
@@ -116,7 +119,8 @@ class _FilterRow extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        Text('$label:', style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500)),
+        Text('$label:',
+            style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500)),
         const SizedBox(width: 8),
         Expanded(
           child: SingleChildScrollView(
@@ -157,8 +161,7 @@ class _SessionCard extends StatelessWidget {
   }
 
   String _formatDate(DateTime dt) {
-    return '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}  '
-        '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
+    return TimezoneUtils.formatDateTime(dt);
   }
 
   @override
@@ -176,8 +179,11 @@ class _SessionCard extends StatelessWidget {
               children: [
                 Expanded(
                   child: Text(
-                    session.title.isNotEmpty ? session.title : session.trainingType,
-                    style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+                    session.title.isNotEmpty
+                        ? session.title
+                        : session.trainingType,
+                    style: const TextStyle(
+                        fontWeight: FontWeight.bold, fontSize: 14),
                   ),
                 ),
                 if (!session.synced)
@@ -212,16 +218,23 @@ class _SessionCard extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      _Stat(icon: Icons.calendar_today, label: _formatDate(session.startTime)),
+                      _Stat(
+                          icon: Icons.calendar_today,
+                          label: _formatDate(session.startTime)),
                       const SizedBox(height: 3),
-                      _Stat(icon: Icons.timer, label: _formatDuration(session.duration)),
+                      _Stat(
+                          icon: Icons.timer,
+                          label: _formatDuration(session.duration)),
                       const SizedBox(height: 3),
                       _Stat(icon: Icons.sports, label: session.trainingType),
                     ],
                   ),
                 ),
                 // Divider
-                Container(width: 1, height: 48, color: Colors.grey.withValues(alpha: 0.25),
+                Container(
+                    width: 1,
+                    height: 48,
+                    color: Colors.grey.withValues(alpha: 0.25),
                     margin: const EdgeInsets.symmetric(horizontal: 10)),
                 // Right: HR stats
                 Expanded(
@@ -229,18 +242,21 @@ class _SessionCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       if (session.avgHeartRate != null)
-                        _Stat(icon: Icons.favorite,
+                        _Stat(
+                            icon: Icons.favorite,
                             label: 'Avg  ${session.avgHeartRate} bpm',
                             color: Colors.orange),
                       if (session.maxHeartRate != null) ...[
                         const SizedBox(height: 3),
-                        _Stat(icon: Icons.trending_up,
+                        _Stat(
+                            icon: Icons.trending_up,
                             label: 'Max  ${session.maxHeartRate} bpm',
                             color: Colors.red),
                       ],
                       if (session.minHeartRate != null) ...[
                         const SizedBox(height: 3),
-                        _Stat(icon: Icons.trending_down,
+                        _Stat(
+                            icon: Icons.trending_down,
                             label: 'Min  ${session.minHeartRate} bpm',
                             color: Colors.blue),
                       ],
@@ -270,7 +286,8 @@ class _Stat extends StatelessWidget {
       children: [
         Icon(icon, size: 13, color: color ?? Colors.grey[600]),
         const SizedBox(width: 3),
-        Text(label, style: TextStyle(fontSize: 12, color: color ?? Colors.grey[700])),
+        Text(label,
+            style: TextStyle(fontSize: 12, color: color ?? Colors.grey[700])),
       ],
     );
   }

--- a/mobile_app/lib/services/hrv_service.dart
+++ b/mobile_app/lib/services/hrv_service.dart
@@ -280,7 +280,7 @@ class HrvService extends ChangeNotifier {
           rrIntervals: (row['rr_intervals'] as List<dynamic>? ?? const [])
               .map((v) => (v as num).toInt())
               .toList(),
-          rmssd: (row['rmssd'] as num).toDouble(),
+          rmssd: (row['rmssd'] as num?)?.toDouble() ?? 0,
           sdnn: (row['sdnn'] as num?)?.toDouble() ?? 0,
           pnn50: (row['pnn50'] as num?)?.toDouble() ?? 0,
           meanRR: (row['mean_rr'] as num?)?.toDouble() ?? 0,

--- a/mobile_app/lib/services/hrv_service.dart
+++ b/mobile_app/lib/services/hrv_service.dart
@@ -194,9 +194,11 @@ class HrvService extends ChangeNotifier {
 
   /// Push all local readiness measurements with [synced == false] to Supabase.
   /// On success each record is updated to [synced: true]. Failures are logged
-  /// and skipped so the rest of the batch still completes.
+  /// and skipped so the rest of the batch still completes. If any record
+  /// failed, the first error is rethrown after all records have been attempted.
   Future<void> syncAllUnsyncedReadiness(SupabaseRepository repo) async {
     if (_readinessBox == null) return;
+    Object? firstError;
     for (final key in List<dynamic>.from(_readinessBox!.keys)) {
       final raw = _readinessBox!.get(key as String);
       if (raw == null) continue;
@@ -250,9 +252,11 @@ class HrvService extends ChangeNotifier {
         debugPrint('[HrvService] Synced readiness measurement ${m.id}');
       } catch (e) {
         debugPrint('[HrvService] Failed to sync readiness measurement ${m.id}: $e');
+        firstError ??= e;
       }
     }
     notifyListeners();
+    if (firstError != null) throw firstError!;
   }
 
   /// Pull readiness measurements from Supabase and insert any that are missing

--- a/mobile_app/lib/services/hrv_service.dart
+++ b/mobile_app/lib/services/hrv_service.dart
@@ -7,6 +7,7 @@ import 'package:uuid/uuid.dart';
 import '../models/daily_hrv_snapshot.dart';
 import '../models/readiness_measurement.dart';
 import '../utils/hrv_analysis.dart';
+import 'supabase_repository.dart';
 
 class HrvService extends ChangeNotifier {
   static final HrvService instance = HrvService._internal();
@@ -186,6 +187,117 @@ class HrvService extends ChangeNotifier {
   Future<void> deleteReadinessMeasurement(String id) async {
     if (_readinessBox == null) return;
     await _readinessBox!.delete(id);
+    notifyListeners();
+  }
+
+  // ── Cloud sync ────────────────────────────────────────────────────────────
+
+  /// Push all local readiness measurements with [synced == false] to Supabase.
+  /// On success each record is updated to [synced: true]. Failures are logged
+  /// and skipped so the rest of the batch still completes.
+  Future<void> syncAllUnsyncedReadiness(SupabaseRepository repo) async {
+    if (_readinessBox == null) return;
+    for (final key in List<dynamic>.from(_readinessBox!.keys)) {
+      final raw = _readinessBox!.get(key as String);
+      if (raw == null) continue;
+      ReadinessMeasurement m;
+      try {
+        m = ReadinessMeasurement.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+      } catch (e) {
+        debugPrint('[HrvService] Failed to decode readiness record $key: $e');
+        continue;
+      }
+      if (m.synced) continue;
+      try {
+        await repo.upsertReadinessMeasurement({
+          'id': m.id,
+          'person_id': m.personId,
+          'device_id': m.deviceId,
+          'measured_at': m.measuredAt.toIso8601String(),
+          'duration_sec': m.durationSec,
+          'rr_intervals': m.rrIntervals,
+          'rmssd': m.rmssd,
+          'sdnn': m.sdnn,
+          'pnn50': m.pnn50,
+          'mean_rr': m.meanRR,
+          'sd1': m.sd1,
+          'sd2': m.sd2,
+          'resting_hr': m.restingHR,
+          'quality_pct': m.qualityPct,
+          'readiness_pct': m.readinessPct,
+          'feeling': m.feelingScore,
+        });
+        final synced = ReadinessMeasurement(
+          id: m.id,
+          personId: m.personId,
+          deviceId: m.deviceId,
+          measuredAt: m.measuredAt,
+          durationSec: m.durationSec,
+          rrIntervals: m.rrIntervals,
+          rmssd: m.rmssd,
+          sdnn: m.sdnn,
+          pnn50: m.pnn50,
+          meanRR: m.meanRR,
+          sd1: m.sd1,
+          sd2: m.sd2,
+          restingHR: m.restingHR,
+          qualityPct: m.qualityPct,
+          readinessPct: m.readinessPct,
+          feelingScore: m.feelingScore,
+          synced: true,
+        );
+        await _readinessBox!.put(m.id, jsonEncode(synced.toJson()));
+        debugPrint('[HrvService] Synced readiness measurement ${m.id}');
+      } catch (e) {
+        debugPrint('[HrvService] Failed to sync readiness measurement ${m.id}: $e');
+      }
+    }
+    notifyListeners();
+  }
+
+  /// Pull readiness measurements from Supabase and insert any that are missing
+  /// locally. Existing local records are not overwritten (local wins).
+  Future<void> syncDownReadinessFromCloud(SupabaseRepository repo) async {
+    if (_readinessBox == null) return;
+    List<Map<String, dynamic>> remote;
+    try {
+      remote = await repo.fetchReadinessMeasurements();
+    } catch (e) {
+      debugPrint('[HrvService] Failed to fetch readiness measurements from cloud: $e');
+      return;
+    }
+    for (final row in remote) {
+      final id = row['id'] as String?;
+      if (id == null) continue;
+      if (_readinessBox!.containsKey(id)) continue; // local wins
+      try {
+        final m = ReadinessMeasurement(
+          id: id,
+          personId: (row['person_id'] as String?) ?? '',
+          deviceId: (row['device_id'] as String?) ?? '',
+          measuredAt: DateTime.parse(row['measured_at'] as String),
+          durationSec: (row['duration_sec'] as num?)?.toInt() ?? 0,
+          rrIntervals: (row['rr_intervals'] as List<dynamic>? ?? const [])
+              .map((v) => (v as num).toInt())
+              .toList(),
+          rmssd: (row['rmssd'] as num).toDouble(),
+          sdnn: (row['sdnn'] as num?)?.toDouble() ?? 0,
+          pnn50: (row['pnn50'] as num?)?.toDouble() ?? 0,
+          meanRR: (row['mean_rr'] as num?)?.toDouble() ?? 0,
+          sd1: (row['sd1'] as num?)?.toDouble() ?? 0,
+          sd2: (row['sd2'] as num?)?.toDouble() ?? 0,
+          restingHR: (row['resting_hr'] as num?)?.toInt(),
+          qualityPct: (row['quality_pct'] as num?)?.toDouble() ?? 0,
+          readinessPct: (row['readiness_pct'] as num?)?.toDouble(),
+          feelingScore: (row['feeling'] as num?)?.toInt(),
+          synced: true,
+        );
+        await _readinessBox!.put(id, jsonEncode(m.toJson()));
+        debugPrint('[HrvService] Pulled readiness measurement $id from cloud');
+      } catch (e) {
+        debugPrint('[HrvService] Failed to store cloud readiness record $id: $e');
+      }
+    }
     notifyListeners();
   }
 

--- a/mobile_app/lib/services/supabase_repository.dart
+++ b/mobile_app/lib/services/supabase_repository.dart
@@ -257,6 +257,30 @@ class SupabaseRepository {
     }, onConflict: 'platform');
   }
 
+  // Readiness measurements
+
+  /// Upsert a readiness measurement to Supabase. Idempotent on `id`.
+  Future<void> upsertReadinessMeasurement(Map<String, dynamic> measurement) async {
+    final userId = _client.auth.currentUser?.id;
+    if (userId == null) throw Exception('Not authenticated');
+    await _client.from('readiness_measurements').upsert({
+      ...measurement,
+      'user_id': userId,
+    }, onConflict: 'id');
+  }
+
+  /// Fetch all readiness measurements for the authenticated user.
+  Future<List<Map<String, dynamic>>> fetchReadinessMeasurements() async {
+    final userId = _client.auth.currentUser?.id;
+    if (userId == null) return [];
+    final res = await _client
+        .from('readiness_measurements')
+        .select()
+        .eq('user_id', userId)
+        .order('measured_at', ascending: false);
+    return List<Map<String, dynamic>>.from(res);
+  }
+
   double _estimateCalories(int avgHr, int durationSec, double weightKg, int age, String gender) {
     final durationMin = durationSec / 60.0;
     if (gender == 'male') {

--- a/mobile_app/lib/services/supabase_repository.dart
+++ b/mobile_app/lib/services/supabase_repository.dart
@@ -2,11 +2,27 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../supabase/supabase_client.dart';
+import '../utils/timezone_utils.dart';
 
 class SupabaseRepository {
   SupabaseRepository() : _client = SupabaseClientProvider.client;
 
   final SupabaseClient _client;
+
+  List<Map<String, dynamic>> _normalizeHeartRateData(
+      List<Map<String, dynamic>> data) {
+    return data.map((entry) {
+      final timestamp = entry['timestamp'];
+      final parsed = timestamp is DateTime
+          ? timestamp
+          : (timestamp is String ? DateTime.tryParse(timestamp) : null);
+
+      return {
+        ...entry,
+        if (parsed != null) 'timestamp': TimezoneUtils.toUtcIsoString(parsed),
+      };
+    }).toList();
+  }
 
   // Auth
   Future<AuthResponse> signIn(String email, String password) {
@@ -62,7 +78,10 @@ class SupabaseRepository {
 
   // Sessions
   Future<List<Map<String, dynamic>>> fetchSessions() async {
-    final res = await _client.from('training_sessions').select().order('start_time', ascending: false);
+    final res = await _client
+        .from('training_sessions')
+        .select()
+        .order('start_time', ascending: false);
     return List<Map<String, dynamic>>.from(res);
   }
 
@@ -80,18 +99,20 @@ class SupabaseRepository {
       'title': title,
       'training_type': trainingType,
       'notes': notes,
-      'start_time': DateTime.now().toIso8601String(),
+      'start_time': TimezoneUtils.toUtcIsoString(DateTime.now()),
       'heart_rate_data': jsonEncode([]),
     });
   }
 
-  Future<void> appendHeartRate(String sessionId, List<Map<String, dynamic>> data) async {
+  Future<void> appendHeartRate(
+      String sessionId, List<Map<String, dynamic>> data) async {
     await _client.from('training_sessions').update({
       'heart_rate_data': jsonEncode(data),
     }).eq('id', sessionId);
   }
 
-  Future<void> endSession(String sessionId, {
+  Future<void> endSession(
+    String sessionId, {
     required DateTime startTime,
     required List<int> heartRates,
     required double weight,
@@ -110,7 +131,7 @@ class SupabaseRepository {
       calories = _estimateCalories(avg, duration, weight, age, gender);
     }
     await _client.from('training_sessions').update({
-      'end_time': endTime.toIso8601String(),
+      'end_time': TimezoneUtils.toUtcIsoString(endTime),
       'duration': duration,
       'avg_heart_rate': avg,
       'max_heart_rate': max,
@@ -118,7 +139,7 @@ class SupabaseRepository {
       'calories': calories,
       'notes': notes,
       'synced': true,
-      'updated_at': DateTime.now().toIso8601String(),
+      'updated_at': TimezoneUtils.toUtcIsoString(DateTime.now()),
     }).eq('id', sessionId);
   }
 
@@ -141,35 +162,36 @@ class SupabaseRepository {
   }) async {
     final userId = _client.auth.currentUser?.id;
     if (userId == null) throw Exception('Not authenticated');
-    
+
     try {
       debugPrint('Upserting session $id to Supabase');
       debugPrint('  person_id: $personId');
       debugPrint('  user_id: $userId');
       debugPrint('  title: $title');
       debugPrint('  heart_rate_data points: ${heartRateData.length}');
-      
+
       final payload = {
         'id': id,
         'user_id': userId,
         'person_id': personId,
         'title': title,
         'training_type': trainingType,
-        'start_time': startTime.toIso8601String(),
-        'end_time': endTime.toIso8601String(),
+        'start_time': TimezoneUtils.toUtcIsoString(startTime),
+        'end_time': TimezoneUtils.toUtcIsoString(endTime),
         'duration': duration,
         'avg_heart_rate': avgHeartRate,
         'max_heart_rate': maxHeartRate,
         'min_heart_rate': minHeartRate,
         'calories': calories,
-        'heart_rate_data': jsonEncode(heartRateData),
+        'heart_rate_data': jsonEncode(_normalizeHeartRateData(heartRateData)),
         'notes': notes,
         'synced': true,
-        'created_at': startTime.toIso8601String(),
-        'updated_at': DateTime.now().toIso8601String(),
+        'created_at': TimezoneUtils.toUtcIsoString(startTime),
+        'updated_at': TimezoneUtils.toUtcIsoString(DateTime.now()),
       };
-      
-      final result = await _client.from('training_sessions').upsert(payload).select();
+
+      final result =
+          await _client.from('training_sessions').upsert(payload).select();
       debugPrint('Supabase upsert result: $result');
     } catch (e) {
       debugPrint('Error upserting training session: $e');
@@ -260,11 +282,20 @@ class SupabaseRepository {
   // Readiness measurements
 
   /// Upsert a readiness measurement to Supabase. Idempotent on `id`.
-  Future<void> upsertReadinessMeasurement(Map<String, dynamic> measurement) async {
+  Future<void> upsertReadinessMeasurement(
+      Map<String, dynamic> measurement) async {
     final userId = _client.auth.currentUser?.id;
     if (userId == null) throw Exception('Not authenticated');
+    final measuredAt = measurement['measured_at'];
+
     await _client.from('readiness_measurements').upsert({
       ...measurement,
+      if (measuredAt is DateTime)
+        'measured_at': TimezoneUtils.toUtcIsoString(measuredAt)
+      else if (measuredAt is String)
+        'measured_at': DateTime.tryParse(measuredAt) != null
+            ? TimezoneUtils.toUtcIsoString(DateTime.parse(measuredAt))
+            : measuredAt,
       'user_id': userId,
     }, onConflict: 'id');
   }
@@ -281,12 +312,23 @@ class SupabaseRepository {
     return List<Map<String, dynamic>>.from(res);
   }
 
-  double _estimateCalories(int avgHr, int durationSec, double weightKg, int age, String gender) {
+  double _estimateCalories(
+      int avgHr, int durationSec, double weightKg, int age, String gender) {
     final durationMin = durationSec / 60.0;
     if (gender == 'male') {
-      return ((age * 0.2017) - (weightKg * 0.09036) + (avgHr * 0.6309) - 55.0969) * durationMin / 4.184;
+      return ((age * 0.2017) -
+              (weightKg * 0.09036) +
+              (avgHr * 0.6309) -
+              55.0969) *
+          durationMin /
+          4.184;
     } else {
-      return ((age * 0.074) - (weightKg * 0.05741) + (avgHr * 0.4472) - 20.4022) * durationMin / 4.184;
+      return ((age * 0.074) -
+              (weightKg * 0.05741) +
+              (avgHr * 0.4472) -
+              20.4022) *
+          durationMin /
+          4.184;
     }
   }
 }

--- a/mobile_app/lib/services/sync_service.dart
+++ b/mobile_app/lib/services/sync_service.dart
@@ -8,6 +8,7 @@ import 'database_service.dart';
 import 'hrv_service.dart';
 import 'settings_service.dart';
 import 'supabase_repository.dart';
+import '../utils/timezone_utils.dart';
 
 class SyncService extends ChangeNotifier {
   bool _isSyncing = false;
@@ -23,9 +24,19 @@ class SyncService extends ChangeNotifier {
   }
 
   bool get isSyncing => _isSyncing;
-  bool get isAuthenticated => SupabaseClientProvider.client.auth.currentSession != null;
+  bool get isAuthenticated =>
+      SupabaseClientProvider.client.auth.currentSession != null;
 
   SupabaseClient get _client => SupabaseClientProvider.client;
+
+  List<Map<String, dynamic>> _normalizeHeartRateData(List<HeartRateData> data) {
+    return data
+        .map((entry) => {
+              ...entry.toJson(),
+              'timestamp': TimezoneUtils.toUtcIsoString(entry.timestamp),
+            })
+        .toList();
+  }
 
   Future<void> _syncOnLogin() async {
     if (_isSyncing) return;
@@ -88,15 +99,17 @@ class SyncService extends ChangeNotifier {
       'user_id': user.id,
       'person_id': session.personId,
       'title': session.title,
-      'start_time': session.startTime.toIso8601String(),
-      'end_time': session.endTime?.toIso8601String(),
+      'start_time': TimezoneUtils.toUtcIsoString(session.startTime),
+      'end_time': session.endTime != null
+          ? TimezoneUtils.toUtcIsoString(session.endTime!)
+          : null,
       'duration': session.duration,
       'avg_heart_rate': session.avgHeartRate,
       'max_heart_rate': session.maxHeartRate,
       'min_heart_rate': session.minHeartRate,
       'calories': session.calories,
       'training_type': session.trainingType,
-      'heart_rate_data': session.heartRateData.map((e) => e.toJson()).toList(),
+      'heart_rate_data': _normalizeHeartRateData(session.heartRateData),
       'notes': session.notes,
     }, onConflict: 'id');
   }

--- a/mobile_app/lib/services/sync_service.dart
+++ b/mobile_app/lib/services/sync_service.dart
@@ -5,6 +5,7 @@ import '../models/training_session.dart';
 import '../supabase/supabase_client.dart';
 import 'app_initializer.dart';
 import 'database_service.dart';
+import 'hrv_service.dart';
 import 'settings_service.dart';
 import 'supabase_repository.dart';
 
@@ -35,12 +36,15 @@ class SyncService extends ChangeNotifier {
       await AppInitializer.instance.initFuture;
       final db = DatabaseService.instance;
       final settings = SettingsService.instance;
+      final hrv = HrvService.instance;
       // Pull cloud data down first
       await settings.syncDownFromCloud(_repo);
       await db.syncDownFromCloud(_repo);
+      await hrv.syncDownReadinessFromCloud(_repo);
       // Push local data up
       await settings.syncUpToCloud(_repo);
       await db.syncAllUnsyncedSessions(_repo);
+      await hrv.syncAllUnsyncedReadiness(_repo);
     } finally {
       _isSyncing = false;
       notifyListeners();

--- a/mobile_app/lib/utils/timezone_utils.dart
+++ b/mobile_app/lib/utils/timezone_utils.dart
@@ -1,0 +1,28 @@
+class TimezoneUtils {
+  static const Duration _gmt8Offset = Duration(hours: 8);
+
+  static DateTime toGmt8(DateTime value) => value.toUtc().add(_gmt8Offset);
+
+  static String formatDate(DateTime value) {
+    final gmt8 = toGmt8(value);
+    return '${gmt8.year.toString().padLeft(4, '0')}-'
+        '${gmt8.month.toString().padLeft(2, '0')}-'
+        '${gmt8.day.toString().padLeft(2, '0')}';
+  }
+
+  static String formatTime(DateTime value, {bool includeSeconds = false}) {
+    final gmt8 = toGmt8(value);
+    final hour = gmt8.hour.toString().padLeft(2, '0');
+    final minute = gmt8.minute.toString().padLeft(2, '0');
+    if (!includeSeconds) return '$hour:$minute';
+    final second = gmt8.second.toString().padLeft(2, '0');
+    return '$hour:$minute:$second';
+  }
+
+  static String formatDateTime(DateTime value, {bool includeSeconds = false}) {
+    return '${formatDate(value)} ${formatTime(value, includeSeconds: includeSeconds)}';
+  }
+
+  static String toUtcIsoString(DateTime value) =>
+      value.toUtc().toIso8601String();
+}

--- a/supabase/migrations/004_backfill_legacy_gmt8_session_timestamps.sql
+++ b/supabase/migrations/004_backfill_legacy_gmt8_session_timestamps.sql
@@ -1,0 +1,46 @@
+-- Backfill legacy mobile-written session timestamps that were serialized as
+-- local GMT+8 wall-clock values without a timezone offset.
+--
+-- Detection rule:
+-- - legacy mobile sessions were titled like "Training Session YYYY-MM-DD HH:MM"
+-- - the buggy rows stored that same wall-clock value directly in start_time as UTC
+--
+-- For example:
+--   title      = Training Session 2026-05-06 11:46
+--   start_time = 2026-05-06 11:46:18+00   -- wrong, should be 03:46:18+00
+
+WITH legacy_sessions AS (
+  SELECT id
+  FROM public.training_sessions
+  WHERE title ~ '^Training Session [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}$'
+    AND regexp_replace(title, '^Training Session ', '') = to_char(start_time AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI')
+)
+UPDATE public.training_sessions AS ts
+SET start_time = ts.start_time - interval '8 hours',
+    end_time = CASE
+      WHEN ts.end_time IS NULL THEN NULL
+      ELSE ts.end_time - interval '8 hours'
+    END,
+    created_at = ts.created_at - interval '8 hours',
+    heart_rate_data = (
+      SELECT COALESCE(
+        jsonb_agg(
+          CASE
+            WHEN sample ? 'timestamp'
+              AND jsonb_typeof(sample->'timestamp') = 'string'
+              AND sample->>'timestamp' ~ '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?$'
+            THEN jsonb_set(
+              sample,
+              '{timestamp}',
+              to_jsonb(((sample->>'timestamp')::timestamp - interval '8 hours') AT TIME ZONE 'UTC')
+            )
+            ELSE sample
+          END
+          ORDER BY ordinality
+        ),
+        '[]'::jsonb
+      )
+      FROM jsonb_array_elements(ts.heart_rate_data) WITH ORDINALITY AS samples(sample, ordinality)
+    )
+FROM legacy_sessions
+WHERE ts.id = legacy_sessions.id;

--- a/supabase/migrations/005_user_settings.sql
+++ b/supabase/migrations/005_user_settings.sql
@@ -1,0 +1,29 @@
+-- User settings table
+-- Stores per-user category and group configuration synced from the mobile app.
+-- One row per authenticated user; upserted on every settings save.
+
+CREATE TABLE IF NOT EXISTS public.user_settings (
+  user_id     uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  categories  jsonb NOT NULL DEFAULT '[]',
+  groups      jsonb NOT NULL DEFAULT '[]',
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Row-level security: users only see and modify their own settings
+ALTER TABLE public.user_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own settings"
+  ON public.user_settings FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own settings"
+  ON public.user_settings FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own settings"
+  ON public.user_settings FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own settings"
+  ON public.user_settings FOR DELETE
+  USING (auth.uid() = user_id);

--- a/web_app/src/App.jsx
+++ b/web_app/src/App.jsx
@@ -9,6 +9,7 @@ import Sessions from './pages/Sessions'
 import SessionDetail from './pages/SessionDetail'
 import PersonsManagement from './pages/PersonsManagement'
 import HistoryAnalysis from './pages/HistoryAnalysis'
+import ReadinessHistory from './pages/ReadinessHistory'
 import Settings from './pages/Settings'
 import { authService } from './services/api'
 import { supabase } from './services/supabaseClient'
@@ -67,6 +68,7 @@ function App() {
             <Route path="/sessions/:id" element={<PrivateRoute><SessionDetail /></PrivateRoute>} />
             <Route path="/persons" element={<PrivateRoute><PersonsManagement /></PrivateRoute>} />
             <Route path="/analysis" element={<PrivateRoute><HistoryAnalysis /></PrivateRoute>} />
+            <Route path="/readiness" element={<PrivateRoute><ReadinessHistory /></PrivateRoute>} />
             <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
             <Route path="*" element={<Navigate to="/" />} />
           </Route>

--- a/web_app/src/components/TabSidebar.jsx
+++ b/web_app/src/components/TabSidebar.jsx
@@ -8,6 +8,7 @@ const NAV_LINKS = [
   { to: '/persons',    icon: '👥', label: 'Athletes' },
   { to: '/sessions',   icon: '📝', label: 'Sessions' },
   { to: '/analysis',   icon: '📈', label: 'Analysis' },
+  { to: '/readiness',  icon: '💓', label: 'Readiness' },
   { to: '/settings',   icon: '⚙️',  label: 'Settings' },
 ]
 

--- a/web_app/src/lib/dateTime.js
+++ b/web_app/src/lib/dateTime.js
@@ -1,0 +1,73 @@
+const GMT_PLUS_8_TIME_ZONE = 'Asia/Shanghai'
+
+function getDate(value) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function getParts(value, options) {
+  const date = getDate(value)
+  if (!date) return null
+
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: GMT_PLUS_8_TIME_ZONE,
+    hour12: false,
+    ...options,
+  })
+
+  return formatter.formatToParts(date).reduce((parts, part) => {
+    if (part.type !== 'literal') {
+      parts[part.type] = part.value
+    }
+    return parts
+  }, {})
+}
+
+export function formatDateGMT8(value) {
+  const parts = getParts(value, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+  if (!parts) return ''
+  return `${parts.year}-${parts.month}-${parts.day}`
+}
+
+export function formatTimeGMT8(value, { seconds = true } = {}) {
+  const parts = getParts(value, {
+    hour: '2-digit',
+    minute: '2-digit',
+    ...(seconds ? { second: '2-digit' } : {}),
+  })
+  if (!parts) return ''
+  return seconds
+    ? `${parts.hour}:${parts.minute}:${parts.second}`
+    : `${parts.hour}:${parts.minute}`
+}
+
+export function formatDateTimeGMT8(value, { seconds = true } = {}) {
+  const date = formatDateGMT8(value)
+  const time = formatTimeGMT8(value, { seconds })
+  if (!date || !time) return ''
+  return `${date} ${time}`
+}
+
+export function formatMonthLabelGMT8(value) {
+  const date = getDate(value)
+  if (!date) return ''
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: GMT_PLUS_8_TIME_ZONE,
+    year: 'numeric',
+    month: 'short',
+  }).format(date)
+}
+
+export function formatMonthKeyGMT8(value) {
+  const parts = getParts(value, {
+    year: 'numeric',
+    month: '2-digit',
+  })
+  if (!parts) return ''
+  return `${parts.year}-${parts.month}`
+}

--- a/web_app/src/pages/Dashboard.jsx
+++ b/web_app/src/pages/Dashboard.jsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { authService } from '../services/api'
 import { useDashboardData } from './hooks/useDashboardData'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts'
+import { formatDateGMT8 } from '../lib/dateTime'
 
 
 function Dashboard() {
@@ -128,7 +129,7 @@ function Dashboard() {
                   <div>
                     <strong>{session.title}</strong>
                     <div style={{ fontSize: '14px', color: '#666', marginTop: '5px' }}>
-                      {new Date(session.startTime).toLocaleDateString()} • {formatDuration(session.duration)}
+                      {formatDateGMT8(session.startTime)} • {formatDuration(session.duration)}
                       {session.avgHeartRate && ` • Avg HR: ${session.avgHeartRate} bpm`}
                     </div>
                   </div>

--- a/web_app/src/pages/HistoryAnalysis.jsx
+++ b/web_app/src/pages/HistoryAnalysis.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { sessionService, personService } from '../services/api'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, BarChart, Bar, PieChart, Pie, Cell } from 'recharts'
 import { getZoneForHR, ZONE_DEFINITIONS } from '../lib/trainingZones'
+import { formatDateGMT8, formatMonthKeyGMT8, formatMonthLabelGMT8 } from '../lib/dateTime'
 
 const HistoryAnalysis = () => {
   const [stats, setStats] = useState(null)
@@ -73,7 +74,7 @@ const HistoryAnalysis = () => {
       .sort((a, b) => new Date(a.startTime) - new Date(b.startTime))
       .slice(-20)
       .map(session => ({
-        date: new Date(session.startTime).toLocaleDateString(),
+        date: formatDateGMT8(session.startTime),
         avgHR: session.avgHeartRate,
         maxHR: session.maxHeartRate,
         person: persons.find(p => p.id === session.personId)?.name || 'Unknown'
@@ -92,11 +93,11 @@ const HistoryAnalysis = () => {
   const prepareMonthlyData = () => {
     const monthlyStats = {}
     sessions.forEach(session => {
-      const date = new Date(session.startTime)
-      const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
+      const monthKey = formatMonthKeyGMT8(session.startTime)
       if (!monthlyStats[monthKey]) {
         monthlyStats[monthKey] = {
-          month: date.toLocaleDateString('en-US', { year: 'numeric', month: 'short' }),
+          month: formatMonthLabelGMT8(session.startTime),
+          monthKey,
           sessions: 0,
           totalDuration: 0,
           totalCalories: 0
@@ -106,7 +107,7 @@ const HistoryAnalysis = () => {
       monthlyStats[monthKey].totalDuration += session.duration || 0
       monthlyStats[monthKey].totalCalories += session.calories || 0
     })
-    return Object.values(monthlyStats).sort((a, b) => a.month.localeCompare(b.month))
+    return Object.values(monthlyStats).sort((a, b) => a.monthKey.localeCompare(b.monthKey))
   }
 
   const prepareZoneSummary = () => {
@@ -314,7 +315,7 @@ const HistoryAnalysis = () => {
                   onMouseEnter={e => e.currentTarget.style.background = '#fafafa'}
                   onMouseLeave={e => e.currentTarget.style.background = ''}
                 >
-                  <td style={tdStyle}>{new Date(session.startTime).toLocaleDateString()}</td>
+                  <td style={tdStyle}>{formatDateGMT8(session.startTime)}</td>
                   <td style={tdStyle}>{persons.find(p => p.id === session.personId)?.name || 'Unknown'}</td>
                   <td style={{ ...tdStyle, textTransform: 'capitalize' }}>{session.trainingType || '-'}</td>
                   <td style={tdStyle}>{session.duration ? `${Math.floor(session.duration / 60)}m ${session.duration % 60}s` : '-'}</td>

--- a/web_app/src/pages/ReadinessHistory.jsx
+++ b/web_app/src/pages/ReadinessHistory.jsx
@@ -4,6 +4,7 @@ import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
   ResponsiveContainer, ReferenceLine,
 } from 'recharts'
+import { formatDateGMT8, formatDateTimeGMT8 } from '../lib/dateTime'
 
 const FEELING_LABELS = { 1: '😞 Very Bad', 2: '😕 Bad', 3: '😐 OK', 4: '🙂 Good', 5: '😄 Very Good' }
 
@@ -80,7 +81,7 @@ const ReadinessHistory = () => {
   const chartData = [...measurements]
     .sort((a, b) => new Date(a.measuredAt) - new Date(b.measuredAt))
     .map(m => ({
-      date: new Date(m.measuredAt).toLocaleDateString(),
+      date: formatDateGMT8(m.measuredAt),
       rmssd: m.rmssd != null ? Math.round(m.rmssd * 10) / 10 : null,
       readiness: m.readinessPct != null ? Math.round(m.readinessPct) : null,
       person: personMap[m.personId]?.name ?? 'Unknown',
@@ -259,7 +260,7 @@ const ReadinessHistory = () => {
                       onMouseEnter={e => e.currentTarget.style.background = '#fafafa'}
                       onMouseLeave={e => e.currentTarget.style.background = ''}
                     >
-                      <td style={tdStyle}>{new Date(m.measuredAt).toLocaleString()}</td>
+                      <td style={tdStyle}>{formatDateTimeGMT8(m.measuredAt, { seconds: true })}</td>
                       <td style={tdStyle}>{personMap[m.personId]?.name ?? 'Unknown'}</td>
                       <td style={{ ...tdStyle, fontWeight: 600, color: readinessColor(m.readinessPct) }}>
                         {m.readinessPct != null

--- a/web_app/src/pages/ReadinessHistory.jsx
+++ b/web_app/src/pages/ReadinessHistory.jsx
@@ -1,0 +1,294 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import { readinessService, personService } from '../services/api'
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+  ResponsiveContainer, ReferenceLine,
+} from 'recharts'
+
+const FEELING_LABELS = { 1: '😞 Very Bad', 2: '😕 Bad', 3: '😐 OK', 4: '🙂 Good', 5: '😄 Very Good' }
+
+function readinessColor(pct) {
+  if (pct == null) return '#888'
+  if (pct >= 90) return '#16a34a'
+  if (pct >= 75) return '#2563eb'
+  if (pct >= 60) return '#d97706'
+  return '#dc2626'
+}
+
+function readinessLabel(pct) {
+  if (pct == null) return 'No baseline'
+  if (pct >= 90) return 'High'
+  if (pct >= 75) return 'Normal'
+  if (pct >= 60) return 'Reduced'
+  return 'Low'
+}
+
+const RANGE_OPTIONS = [
+  { label: '7d', days: 7 },
+  { label: '28d', days: 28 },
+  { label: '60d', days: 60 },
+  { label: 'All', days: null },
+]
+
+const ReadinessHistory = () => {
+  const [measurements, setMeasurements] = useState([])
+  const [persons, setPersons] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [selectedPersonId, setSelectedPersonId] = useState('')
+  const [selectedRange, setSelectedRange] = useState('60d')
+
+  const loadData = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError('')
+      const days = RANGE_OPTIONS.find(o => o.label === selectedRange)?.days ?? null
+      const params = {}
+      if (selectedPersonId) params.personId = selectedPersonId
+      if (days) params.days = days
+      const [mRes, pRes] = await Promise.all([
+        readinessService.getMeasurements(params),
+        personService.getPersons(),
+      ])
+      setMeasurements(mRes.data || [])
+      setPersons(pRes.data || [])
+    } catch (err) {
+      console.error('Error loading readiness data:', err)
+      setError('Failed to load readiness data')
+    } finally {
+      setLoading(false)
+    }
+  }, [selectedPersonId, selectedRange])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete this readiness measurement?')) return
+    try {
+      await readinessService.deleteMeasurement(id)
+      setMeasurements(prev => prev.filter(m => m.id !== id))
+    } catch (err) {
+      alert('Failed to delete measurement')
+    }
+  }
+
+  const personMap = Object.fromEntries(persons.map(p => [p.id, p]))
+
+  // Chart: RMSSD trend (chronological)
+  const chartData = [...measurements]
+    .sort((a, b) => new Date(a.measuredAt) - new Date(b.measuredAt))
+    .map(m => ({
+      date: new Date(m.measuredAt).toLocaleDateString(),
+      rmssd: m.rmssd != null ? Math.round(m.rmssd * 10) / 10 : null,
+      readiness: m.readinessPct != null ? Math.round(m.readinessPct) : null,
+      person: personMap[m.personId]?.name ?? 'Unknown',
+    }))
+
+  // Summary stats
+  const withReadiness = measurements.filter(m => m.readinessPct != null)
+  const avgReadiness = withReadiness.length
+    ? Math.round(withReadiness.reduce((s, m) => s + m.readinessPct, 0) / withReadiness.length)
+    : null
+  const latestReadiness = withReadiness[0]?.readinessPct
+  const avgRmssd = measurements.length
+    ? Math.round(measurements.reduce((s, m) => s + (m.rmssd ?? 0), 0) / measurements.length * 10) / 10
+    : null
+
+  const inputStyle = { padding: '8px 10px', border: '1px solid #ddd', borderRadius: 4, fontSize: 14, background: 'white' }
+  const thStyle = { textAlign: 'left', padding: '10px 14px', borderBottom: '2px solid #eee', fontSize: 12, color: '#888', textTransform: 'uppercase', letterSpacing: '0.5px' }
+  const tdStyle = { padding: '10px 14px', borderBottom: '1px solid #f0f0f0', fontSize: 14 }
+
+  if (loading) {
+    return <div style={{ textAlign: 'center', padding: 60, color: '#999' }}>Loading readiness data...</div>
+  }
+
+  return (
+    <div>
+      <h1 style={{ margin: '0 0 20px', fontSize: 24, fontWeight: 700 }}>Readiness History</h1>
+
+      {/* Filters */}
+      <div className="card" style={{ marginBottom: 20 }}>
+        <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'flex-end' }}>
+          <div style={{ minWidth: 160 }}>
+            <label style={{ display: 'block', marginBottom: 4, fontSize: 13, color: '#555' }}>Athlete</label>
+            <select
+              value={selectedPersonId}
+              onChange={e => setSelectedPersonId(e.target.value)}
+              style={{ ...inputStyle, width: '100%' }}
+            >
+              <option value="">All Athletes</option>
+              {persons.map(p => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label style={{ display: 'block', marginBottom: 4, fontSize: 13, color: '#555' }}>Range</label>
+            <div style={{ display: 'flex', gap: 6 }}>
+              {RANGE_OPTIONS.map(o => (
+                <button
+                  key={o.label}
+                  onClick={() => setSelectedRange(o.label)}
+                  className="btn"
+                  style={{
+                    padding: '8px 14px', fontSize: 13,
+                    background: selectedRange === o.label ? '#2563eb' : '#f0f0f0',
+                    color: selectedRange === o.label ? 'white' : '#333',
+                    border: '1px solid #ddd',
+                  }}
+                >
+                  {o.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {error && <div className="error" style={{ marginBottom: 16 }}>{error}</div>}
+
+      {/* Summary cards */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 16, marginBottom: 24 }}>
+        <div className="card" style={{ marginBottom: 0, textAlign: 'center' }}>
+          <div style={{ fontSize: 13, color: '#888', marginBottom: 6 }}>Measurements</div>
+          <div style={{ fontSize: 32, fontWeight: 700, color: '#2563eb' }}>{measurements.length}</div>
+        </div>
+        <div className="card" style={{ marginBottom: 0, textAlign: 'center' }}>
+          <div style={{ fontSize: 13, color: '#888', marginBottom: 6 }}>Latest Readiness</div>
+          <div style={{ fontSize: 32, fontWeight: 700, color: readinessColor(latestReadiness) }}>
+            {latestReadiness != null ? `${Math.round(latestReadiness)}%` : '—'}
+          </div>
+          {latestReadiness != null && (
+            <div style={{ fontSize: 12, color: readinessColor(latestReadiness) }}>{readinessLabel(latestReadiness)}</div>
+          )}
+        </div>
+        <div className="card" style={{ marginBottom: 0, textAlign: 'center' }}>
+          <div style={{ fontSize: 13, color: '#888', marginBottom: 6 }}>Avg Readiness</div>
+          <div style={{ fontSize: 32, fontWeight: 700, color: readinessColor(avgReadiness) }}>
+            {avgReadiness != null ? `${avgReadiness}%` : '—'}
+          </div>
+        </div>
+        <div className="card" style={{ marginBottom: 0, textAlign: 'center' }}>
+          <div style={{ fontSize: 13, color: '#888', marginBottom: 6 }}>Avg RMSSD</div>
+          <div style={{ fontSize: 32, fontWeight: 700, color: '#7c3aed' }}>
+            {avgRmssd != null ? `${avgRmssd}` : '—'}
+          </div>
+          {avgRmssd != null && <div style={{ fontSize: 12, color: '#888' }}>ms</div>}
+        </div>
+      </div>
+
+      {measurements.length === 0 ? (
+        <div className="card" style={{ textAlign: 'center', padding: 60, color: '#999' }}>
+          <div style={{ fontSize: 48, marginBottom: 16 }}>💓</div>
+          <div style={{ fontSize: 18 }}>No readiness measurements yet</div>
+          <div style={{ fontSize: 14, marginTop: 8 }}>Measure resting HRV in the mobile app to see history here</div>
+        </div>
+      ) : (
+        <>
+          {/* Charts */}
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(400px, 1fr))', gap: 20, marginBottom: 20 }}>
+            <div className="card" style={{ marginBottom: 0 }}>
+              <h3 style={{ margin: '0 0 16px', fontSize: 16, fontWeight: 600 }}>RMSSD Trend (ms)</h3>
+              <ResponsiveContainer width="100%" height={260}>
+                <LineChart data={chartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                  <YAxis tick={{ fontSize: 11 }} />
+                  <Tooltip />
+                  <Line
+                    type="monotone"
+                    dataKey="rmssd"
+                    stroke="#7c3aed"
+                    name="RMSSD (ms)"
+                    dot={{ r: 3 }}
+                    connectNulls
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+
+            <div className="card" style={{ marginBottom: 0 }}>
+              <h3 style={{ margin: '0 0 16px', fontSize: 16, fontWeight: 600 }}>Readiness Score (%)</h3>
+              <ResponsiveContainer width="100%" height={260}>
+                <LineChart data={chartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                  <YAxis domain={[0, 150]} tick={{ fontSize: 11 }} />
+                  <Tooltip formatter={(v) => [`${v}%`, 'Readiness']} />
+                  <ReferenceLine y={90} stroke="#16a34a" strokeDasharray="4 2" label={{ value: 'High', fill: '#16a34a', fontSize: 10 }} />
+                  <ReferenceLine y={75} stroke="#2563eb" strokeDasharray="4 2" label={{ value: 'Normal', fill: '#2563eb', fontSize: 10 }} />
+                  <ReferenceLine y={60} stroke="#d97706" strokeDasharray="4 2" label={{ value: 'Reduced', fill: '#d97706', fontSize: 10 }} />
+                  <Line
+                    type="monotone"
+                    dataKey="readiness"
+                    stroke="#e0192f"
+                    name="Readiness %"
+                    dot={{ r: 3 }}
+                    connectNulls
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          {/* Measurements table */}
+          <div className="card" style={{ marginBottom: 0, padding: 0, overflow: 'hidden' }}>
+            <div style={{ padding: '16px 20px', borderBottom: '1px solid #f0f0f0' }}>
+              <h3 style={{ margin: 0, fontSize: 16, fontWeight: 600 }}>All Measurements</h3>
+            </div>
+            <div style={{ overflowX: 'auto' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr style={{ background: '#fafafa' }}>
+                    <th style={thStyle}>Date</th>
+                    <th style={thStyle}>Athlete</th>
+                    <th style={thStyle}>Readiness</th>
+                    <th style={thStyle}>RMSSD</th>
+                    <th style={thStyle}>Resting HR</th>
+                    <th style={thStyle}>Duration</th>
+                    <th style={thStyle}>Feeling</th>
+                    <th style={thStyle}></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {measurements.map(m => (
+                    <tr
+                      key={m.id}
+                      onMouseEnter={e => e.currentTarget.style.background = '#fafafa'}
+                      onMouseLeave={e => e.currentTarget.style.background = ''}
+                    >
+                      <td style={tdStyle}>{new Date(m.measuredAt).toLocaleString()}</td>
+                      <td style={tdStyle}>{personMap[m.personId]?.name ?? 'Unknown'}</td>
+                      <td style={{ ...tdStyle, fontWeight: 600, color: readinessColor(m.readinessPct) }}>
+                        {m.readinessPct != null
+                          ? `${Math.round(m.readinessPct)}% (${readinessLabel(m.readinessPct)})`
+                          : 'No baseline'}
+                      </td>
+                      <td style={tdStyle}>{m.rmssd != null ? `${m.rmssd.toFixed(1)} ms` : '—'}</td>
+                      <td style={tdStyle}>{m.restingHR != null ? `${m.restingHR} bpm` : '—'}</td>
+                      <td style={tdStyle}>{`${Math.floor(m.durationSec / 60)}m ${m.durationSec % 60}s`}</td>
+                      <td style={tdStyle}>{m.feeling != null ? FEELING_LABELS[m.feeling] : '—'}</td>
+                      <td style={tdStyle}>
+                        <button
+                          onClick={() => handleDelete(m.id)}
+                          style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#dc2626', fontSize: 16 }}
+                          title="Delete"
+                        >
+                          🗑
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default ReadinessHistory

--- a/web_app/src/pages/SessionDetail.jsx
+++ b/web_app/src/pages/SessionDetail.jsx
@@ -3,11 +3,11 @@ import { useParams, Link, useNavigate } from 'react-router-dom'
 import { sessionService, personService } from '../services/api'
 import TrainingZonesChart from '../components/TrainingZonesChart'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts'
-import { format } from 'date-fns'
 import { trimHRData, detectWarmup, detectCooldown, filterNoise, calcStats } from '../lib/hrDataProcessing'
 import { analyzeHRV } from '../lib/hrvAnalysis'
 import { calcTRIMP, estimateRecoveryHours, sessionIntensity, estimateVO2Max, vo2MaxCategory } from '../lib/trainingLoad'
 import { exportTCX, exportGPX } from '../lib/exportFormats'
+import { formatDateTimeGMT8, formatTimeGMT8 } from '../lib/dateTime'
 
 function SessionDetail() {
   const { id } = useParams()
@@ -148,7 +148,7 @@ function SessionDetail() {
     .map((data, index) => ({
       time: index,
       heartRate: data.heartRate,
-      timestamp: format(new Date(data.timestamp), 'HH:mm:ss')
+      timestamp: formatTimeGMT8(data.timestamp, { seconds: true })
     }))
 
   return (
@@ -169,7 +169,7 @@ function SessionDetail() {
             <div>
               <h2>{session.title}</h2>
               <p style={{ color: '#666', marginTop: '10px' }}>
-                {new Date(session.startTime).toLocaleString()}
+                {formatDateTimeGMT8(session.startTime, { seconds: true })}
               </p>
             </div>
             <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
@@ -433,7 +433,7 @@ function SessionDetail() {
             <p><strong>Session ID:</strong> {session.id}</p>
             <p><strong>Person ID:</strong> {session.personId}</p>
             <p><strong>Data Points:</strong> {session.heartRateData?.length || 0}</p>
-            <p><strong>Created:</strong> {new Date(session.createdAt).toLocaleString()}</p>
+            <p><strong>Created:</strong> {formatDateTimeGMT8(session.createdAt, { seconds: true })}</p>
           </div>
         </div>
       </div>

--- a/web_app/src/pages/Sessions.jsx
+++ b/web_app/src/pages/Sessions.jsx
@@ -1,13 +1,14 @@
 import React, { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { sessionService } from '../services/api'
+import { formatDateGMT8, formatDateTimeGMT8 } from '../lib/dateTime'
 
 function exportSessionsToCSV(sessions) {
   const headers = ['Title', 'Type', 'Date', 'Duration (min)', 'Avg HR (bpm)', 'Max HR (bpm)', 'Calories (kcal)', 'Distance (m)']
   const rows = sessions.map(s => [
     `"${(s.title || '').replace(/"/g, '""')}"`,
     s.trainingType || '',
-    s.startTime ? new Date(s.startTime).toLocaleDateString() : '',
+    s.startTime ? formatDateGMT8(s.startTime) : '',
     s.duration ? Math.round(s.duration / 60) : '',
     s.avgHeartRate || '',
     s.maxHeartRate || '',
@@ -147,7 +148,7 @@ function Sessions() {
                   <div style={{ flex: 1 }}>
                     <strong>{session.title}</strong>
                     <div style={{ fontSize: '14px', color: '#666', marginTop: '5px' }}>
-                      <div>{new Date(session.startTime).toLocaleString()}</div>
+                      <div>{formatDateTimeGMT8(session.startTime, { seconds: true })}</div>
                       <div>
                         Duration: {formatDuration(session.duration)} • Type: {session.trainingType}
                       </div>

--- a/web_app/src/services/api.js
+++ b/web_app/src/services/api.js
@@ -1,5 +1,5 @@
 import { supabase } from './supabaseClient'
-export { sessionService, personService } from './db'
+export { sessionService, personService, readinessService } from './db'
 
 export const authService = {
   login: async (email, password) => {

--- a/web_app/src/services/db.js
+++ b/web_app/src/services/db.js
@@ -140,6 +140,59 @@ export const sessionService = {
   },
 }
 
+// snake_case → camelCase for readiness measurement objects
+function toReadiness(row) {
+  if (!row) return null
+  return {
+    id: row.id,
+    personId: row.person_id,
+    deviceId: row.device_id,
+    measuredAt: row.measured_at,
+    durationSec: row.duration_sec,
+    rrIntervals: row.rr_intervals ?? [],
+    rmssd: row.rmssd,
+    sdnn: row.sdnn,
+    pnn50: row.pnn50,
+    meanRR: row.mean_rr,
+    sd1: row.sd1,
+    sd2: row.sd2,
+    restingHR: row.resting_hr,
+    qualityPct: row.quality_pct,
+    readinessPct: row.readiness_pct,
+    feeling: row.feeling,
+    createdAt: row.created_at,
+  }
+}
+
+// --- readinessService ---
+
+export const readinessService = {
+  async getMeasurements({ personId, days } = {}) {
+    let query = supabase
+      .from('readiness_measurements')
+      .select('*')
+      .order('measured_at', { ascending: false })
+    if (personId) query = query.eq('person_id', personId)
+    if (days) {
+      const since = new Date()
+      since.setDate(since.getDate() - days)
+      query = query.gte('measured_at', since.toISOString())
+    }
+    const { data, error } = await query
+    if (error) throw error
+    return { data: (data ?? []).map(toReadiness) }
+  },
+
+  async deleteMeasurement(id) {
+    const { error } = await supabase
+      .from('readiness_measurements')
+      .delete()
+      .eq('id', id)
+    if (error) throw error
+    return { data: { success: true } }
+  },
+}
+
 // --- personService (matches existing export name in api.js) ---
 
 export const personService = {


### PR DESCRIPTION
## Summary
This PR brings the readiness feature set through cloud sync and history views, and fixes the timestamp drift that showed up between mobile and web.

## What Changed
- add readiness measurement persistence, sync, and history flows in the mobile app
- add readiness history support in the web app
- normalize mobile session and readiness writes to UTC before sending them to Supabase
- display session and readiness timestamps in fixed GMT+8 on mobile and web
- add a Supabase backfill migration for legacy training sessions written with the old timezone bug
- add supporting docs and deployment/config updates for the readiness work

## Notes For Review
- the branch currently has two unrelated local uncommitted files in the working tree, but they are not part of this PR because they were not committed
- the backfill migration targets legacy `training_sessions` rows detected by the old mobile title/timestamp pattern

## Testing
- validated edited files with VS Code diagnostics after the timezone changes
- pushed branch: `copilot/compact-readiness-measure-page`